### PR TITLE
feat: 전체 작품 리스트 페이지 구현

### DIFF
--- a/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
+++ b/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
@@ -1,66 +1,54 @@
 "use client";
 
 import { useState } from "react";
+import type { CardItem } from "@/components/common/Card/Card.types";
 import { CardGrid } from "@/components/common/Card/CardGrid";
 import { CollapsingHeader } from "@/components/common/CollapsingHeader/CollapsingHeader";
 import { EmptyState } from "@/components/common/EmptyState/EmptyState";
 import { FilterChip } from "@/components/common/FilterChip/FilterChip";
 import MainFooter from "@/components/common/Footer/MainFooter";
-import type { CardItem } from "@/components/common/Card/Card.types";
 
 interface ArtworksClientProps {
-  artworks: CardItem[];
-  categories: string[];
+	artworks: CardItem[];
+	categories: string[];
 }
 
-export default function ArtworksClient({
-  artworks,
-  categories,
-}: ArtworksClientProps) {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+export default function ArtworksClient({ artworks, categories }: ArtworksClientProps) {
+	const [searchQuery, setSearchQuery] = useState("");
+	const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
-  const filtered = artworks.filter((item) => {
-    const matchCategory =
-      !selectedCategory || item.category === selectedCategory;
-    const matchSearch =
-      !searchQuery ||
-      item.title.includes(searchQuery) ||
-      item.author.includes(searchQuery);
-    return matchCategory && matchSearch;
-  });
+	const filtered = artworks.filter((item) => {
+		const matchCategory = !selectedCategory || item.category === selectedCategory;
+		const matchSearch =
+			!searchQuery || item.title.includes(searchQuery) || item.author.includes(searchQuery);
+		return matchCategory && matchSearch;
+	});
 
-  return (
-    <div className="flex flex-col min-h-screen">
-      <CollapsingHeader
-        title="전체 작품"
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
-        searchPlaceholder="작품명, 작가 명을 검색해요."
-      >
-        <FilterChip
-          label="카테고리"
-          options={categories}
-          selected={selectedCategory}
-          onSelect={setSelectedCategory}
-        />
-      </CollapsingHeader>
+	return (
+		<div className="flex flex-col min-h-screen">
+			<CollapsingHeader
+				title="전체 작품"
+				searchQuery={searchQuery}
+				onSearchChange={setSearchQuery}
+				searchPlaceholder="작품명, 작가 명을 검색해요."
+			>
+				<FilterChip
+					label="카테고리"
+					options={categories}
+					selected={selectedCategory}
+					onSelect={setSelectedCategory}
+				/>
+			</CollapsingHeader>
 
-      <section className="flex flex-col flex-1 px-4 pt-4 pb-6">
-        {filtered.length > 0 ? (
-          <CardGrid
-            items={filtered}
-            getHref={(item) => `/artwork/${item.id}`}
-          />
-        ) : (
-          <EmptyState
-            searchQuery={searchQuery}
-            message="해당하는 작품이 없어요."
-          />
-        )}
-      </section>
+			<section className="flex flex-col flex-1 px-4 pt-4 pb-6">
+				{filtered.length > 0 ? (
+					<CardGrid items={filtered} getHref={(item) => `/artwork/${item.id}`} />
+				) : (
+					<EmptyState searchQuery={searchQuery} message="해당하는 작품이 없어요." />
+				)}
+			</section>
 
-      <MainFooter />
-    </div>
-  );
+			<MainFooter />
+		</div>
+	);
 }

--- a/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
+++ b/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { CardGrid } from "@/components/common/Card/CardGrid";
+import { CollapsingHeader } from "@/components/common/CollapsingHeader/CollapsingHeader";
+import { EmptyState } from "@/components/common/EmptyState/EmptyState";
+import { FilterChip } from "@/components/common/FilterChip/FilterChip";
+import MainFooter from "@/components/common/Footer/MainFooter";
+import type { CardItem } from "@/components/common/Card/Card.types";
+
+interface ArtworksClientProps {
+  artworks: CardItem[];
+  categories: string[];
+}
+
+export default function ArtworksClient({
+  artworks,
+  categories,
+}: ArtworksClientProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const filtered = artworks.filter((item) => {
+    const matchCategory =
+      !selectedCategory || item.category === selectedCategory;
+    const matchSearch =
+      !searchQuery ||
+      item.title.includes(searchQuery) ||
+      item.author.includes(searchQuery);
+    return matchCategory && matchSearch;
+  });
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <CollapsingHeader
+        title="전체 작품"
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        searchPlaceholder="작품명, 작가 명을 검색해요."
+      >
+        <FilterChip
+          label="카테고리"
+          options={categories}
+          selected={selectedCategory}
+          onSelect={setSelectedCategory}
+        />
+      </CollapsingHeader>
+
+      <section className="flex flex-col flex-1 px-4 pt-4 pb-6">
+        {filtered.length > 0 ? (
+          <CardGrid
+            items={filtered}
+            getHref={(item) => `/artwork/${item.id}`}
+          />
+        ) : (
+          <EmptyState
+            searchQuery={searchQuery}
+            message="해당하는 작품이 없어요."
+          />
+        )}
+      </section>
+
+      <MainFooter />
+    </div>
+  );
+}

--- a/apps/client/app/(main)/artworks/page.tsx
+++ b/apps/client/app/(main)/artworks/page.tsx
@@ -1,0 +1,14 @@
+import { CATEGORIES, MOCK_ARTWORKS } from "../_mocks/artwork";
+import ArtworksClient from "./_components/ArtworksClient";
+
+const categories = CATEGORIES.filter((c) => c !== "전체");
+
+const allArtworks = [
+	...new Map(
+		categories.flatMap((c) => MOCK_ARTWORKS[c]).map((item) => [item.id, item]),
+	).values(),
+];
+
+export default function ArtworksPage() {
+	return <ArtworksClient artworks={allArtworks} categories={[...categories]} />;
+}

--- a/apps/client/app/(main)/artworks/page.tsx
+++ b/apps/client/app/(main)/artworks/page.tsx
@@ -4,9 +4,7 @@ import ArtworksClient from "./_components/ArtworksClient";
 const categories = CATEGORIES.filter((c) => c !== "전체");
 
 const allArtworks = [
-	...new Map(
-		categories.flatMap((c) => MOCK_ARTWORKS[c]).map((item) => [item.id, item]),
-	).values(),
+	...new Map(categories.flatMap((c) => MOCK_ARTWORKS[c]).map((item) => [item.id, item])).values(),
 ];
 
 export default function ArtworksPage() {

--- a/apps/client/components/common/Card/Card.types.ts
+++ b/apps/client/components/common/Card/Card.types.ts
@@ -11,4 +11,5 @@ export interface CardProps extends Omit<CardItem, "id"> {}
 export interface CardGridProps {
 	items: CardItem[];
 	limit?: number;
+	getHref?: (item: CardItem) => string;
 }

--- a/apps/client/components/common/Card/CardGrid.tsx
+++ b/apps/client/components/common/Card/CardGrid.tsx
@@ -1,14 +1,21 @@
+import Link from "next/link";
 import { Card } from "./Card";
 import type { CardGridProps } from "./Card.types";
 
-export const CardGrid = ({ items, limit }: CardGridProps) => {
+export const CardGrid = ({ items, limit, getHref }: CardGridProps) => {
 	const displayedItems = limit ? items.slice(0, limit) : items;
 
 	return (
 		<div className="grid grid-cols-2 gap-x-4 gap-y-6 w-full">
-			{displayedItems.map((item) => (
-				<Card key={item.id} {...item} />
-			))}
+			{displayedItems.map((item) =>
+				getHref ? (
+					<Link key={item.id} href={getHref(item)}>
+						<Card {...item} />
+					</Link>
+				) : (
+					<Card key={item.id} {...item} />
+				),
+			)}
 		</div>
 	);
 };


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
- 전체 작품 리스트 페이지 (/artworks) 구현
- CardGrid에 getHref prop 추가 (카드 클릭 시 링크 이동)

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

`CollapsingHeader`, `FilterChip`, `EmptyState`, `CardGrid` 모두 기존 공통 컴포넌트 재사용했습니다.
                                                                                   
각 작품 카드 클릭 시 `/artwork/:id` 로 이동하며, 상세 페이지 구현 시 해당 라우트에 연결하면 됩니다.

## 📸 스크린샷

| 구현 내용 |             540             |            375px            |            320px            |
| :-------: | :-------------------------: | :-------------------------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/6b0f8055-3c9b-441f-9fcf-5be73af5ba26" width ="250"> | <img src = "https://github.com/user-attachments/assets/892c9d13-d18a-4ffe-afd4-9794a047ff3d" width ="250"> | <img src = "https://github.com/user-attachments/assets/7d67efd6-3594-4258-8b8f-1c37739253d5" width ="250"> |

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`카테고리 필터링`

- 카테고리별로 분리된 `MOCK_ARTWORKS` Record를 flat 배열로 변환 후 `id` 기준 중복 제거해서 전달하고, 클라이언트에서 `item.category`로 직접 필터링

```typescript                                                               
  // page.tsx - 중복 제거된 전체 목록 생성
  const allArtworks = [                                                            
    ...new Map(
      categories.flatMap((c) => MOCK_ARTWORKS[c]).map((item) => [item.id, item]),  
    ).values(),                                                                  
  ];                                                                               
                                                                                 
  // ArtworksClient.tsx - category + search 동시 필터링                            
  const filtered = artworks.filter((item) => {
    const matchCategory = !selectedCategory || item.category === selectedCategory; 
    const matchSearch =                                                            
      !searchQuery || item.title.includes(searchQuery) ||
  item.author.includes(searchQuery);                                               
    return matchCategory && matchSearch;                                         
  });

```

`CardGrid getHref 추가`
기존 cardGrid는 링크 없이 카드만 렌더링했는데, getHref를 prop을 추가해 선택적으로 link를 감쌀 수 있게 변경했습니다. getHref 없으면 기존 동작 그대로입니다.

```ts
  // getHref 있을 때만 Link로 감쌈                                               
  getHref ? (
    <Link key={item.id} href={getHref(item)}>                                      
      <Card {...item} />
    </Link>                                                                        
  ) : (                                                                          
    <Card key={item.id} {...item} />
  )                                                                                
  
  // 사용 시                                                                       
  <CardGrid items={filtered} getHref={(item) => `/artwork/${item.id}`} />
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- closed #28
