### PR TITLE
feat: bts 목록 페이지 구현

### DIFF
--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/_components/BehindTheSceneClient.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/_components/BehindTheSceneClient.tsx
@@ -2,98 +2,84 @@
 
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
-import { EmptyState } from "@/components/common/EmptyState/EmptyState";
 import { ListCardGrid } from "@/components/common/Card/ListCard/ListCardGrid";
+import { EmptyState } from "@/components/common/EmptyState/EmptyState";
 import { SearchBar } from "@/components/common/SearchBar/SearchBar";
 import { Title } from "@/components/common/Title/Title";
 import { Header } from "../../_components/Header";
 import type { BehindTheSceneItem } from "../_mocks/behind-the-scene";
 
 interface BehindTheSceneClientProps {
-  items: BehindTheSceneItem[];
+	items: BehindTheSceneItem[];
 }
 
 const COLLAPSE_THRESHOLD = 150;
 const EXPAND_THRESHOLD = 20;
 
-export default function BehindTheSceneClient({
-  items,
-}: BehindTheSceneClientProps) {
-  const params = useParams();
-  const schoolId = Array.isArray(params.schoolId)
-    ? params.schoolId[0]
-    : params.schoolId;
-  const exhibitionId = Array.isArray(params.exhibitionId)
-    ? params.exhibitionId[0]
-    : params.exhibitionId;
+export default function BehindTheSceneClient({ items }: BehindTheSceneClientProps) {
+	const params = useParams();
+	const schoolId = Array.isArray(params.schoolId) ? params.schoolId[0] : params.schoolId;
+	const exhibitionId = Array.isArray(params.exhibitionId)
+		? params.exhibitionId[0]
+		: params.exhibitionId;
 
-  const [isScrolled, setIsScrolled] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
+	const [isScrolled, setIsScrolled] = useState(false);
+	const [searchQuery, setSearchQuery] = useState("");
 
-  useEffect(() => {
-    const handleScroll = () => {
-      const y = window.scrollY;
-      setIsScrolled((prev) => {
-        if (!prev && y > COLLAPSE_THRESHOLD) return true;
-        if (prev && y < EXPAND_THRESHOLD) return false;
-        return prev;
-      });
-    };
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+	useEffect(() => {
+		const handleScroll = () => {
+			const y = window.scrollY;
+			setIsScrolled((prev) => {
+				if (!prev && y > COLLAPSE_THRESHOLD) return true;
+				if (prev && y < EXPAND_THRESHOLD) return false;
+				return prev;
+			});
+		};
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		return () => window.removeEventListener("scroll", handleScroll);
+	}, []);
 
-  const filtered = items.filter(
-    (item) =>
-      !searchQuery ||
-      item.title.includes(searchQuery) ||
-      item.author.includes(searchQuery),
-  );
+	const filtered = items.filter(
+		(item) => !searchQuery || item.title.includes(searchQuery) || item.author.includes(searchQuery),
+	);
 
-  return (
-    <div className="flex flex-col min-h-screen">
-      <div className="sticky top-0 z-10 bg-normal">
-        <Header />
+	return (
+		<div className="flex flex-col min-h-screen">
+			<div className="sticky top-0 z-10 bg-normal">
+				<Header />
 
-        {/* 스크롤 전에만 보이는 타이틀 + 서브타이틀 */}
-        <div
-          className={`px-4 overflow-hidden transition-all duration-200 mb-3 ${
-            isScrolled ? "max-h-0 opacity-0" : "max-h-32 opacity-100"
-          }`}
-        >
-          <Title title="Behind The Scene" />
-          <p className="text-body2 text-light">
-            작품의 제작 과정을 확인할 수 있습니다.
-          </p>
-        </div>
+				{/* 스크롤 전에만 보이는 타이틀 + 서브타이틀 */}
+				<div
+					className={`px-4 overflow-hidden transition-all duration-200 mb-3 ${
+						isScrolled ? "max-h-0 opacity-0" : "max-h-32 opacity-100"
+					}`}
+				>
+					<Title title="Behind The Scene" />
+					<p className="text-body2 text-light">작품의 제작 과정을 확인할 수 있습니다.</p>
+				</div>
 
-        {/* 검색바 */}
-        <div className="px-4 pb-6">
-          <SearchBar
-            placeholder="제목 혹은 작가명을 검색해요."
-            value={searchQuery}
-            onChange={setSearchQuery}
-          />
-        </div>
-      </div>
+				{/* 검색바 */}
+				<div className="px-4 pb-6">
+					<SearchBar
+						placeholder="제목 혹은 작가명을 검색해요."
+						value={searchQuery}
+						onChange={setSearchQuery}
+					/>
+				</div>
+			</div>
 
-      {/* 카드 목록 */}
-      <section className="flex flex-col flex-1 px-4 pt-4 pb-6">
-        {filtered.length > 0 ? (
-          <ListCardGrid
-            items={filtered}
-            getHref={(item) =>
-              `/${schoolId}/exhibition/${exhibitionId}/bts/${item.id}`
-            }
-            className="gap-y-10"
-          />
-        ) : (
-          <EmptyState
-            searchQuery={searchQuery}
-            message="등록된 Behind The Scene이 없어요."
-          />
-        )}
-      </section>
-    </div>
-  );
+			{/* 카드 목록 */}
+			<section className="flex flex-col flex-1 px-4 pt-4 pb-6">
+				{filtered.length > 0 ? (
+					<ListCardGrid
+						items={filtered}
+						getHref={(item) => `/${schoolId}/exhibition/${exhibitionId}/bts/${item.id}`}
+						className="gap-y-10"
+					/>
+				) : (
+					<EmptyState searchQuery={searchQuery} message="등록된 Behind The Scene이 없어요." />
+				)}
+			</section>
+		</div>
+	);
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/_components/BehindTheSceneClient.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/_components/BehindTheSceneClient.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { EmptyState } from "@/components/common/EmptyState/EmptyState";
+import { ListCardGrid } from "@/components/common/Card/ListCard/ListCardGrid";
+import { SearchBar } from "@/components/common/SearchBar/SearchBar";
+import { Title } from "@/components/common/Title/Title";
+import { Header } from "../../_components/Header";
+import type { BehindTheSceneItem } from "../_mocks/behind-the-scene";
+
+interface BehindTheSceneClientProps {
+  items: BehindTheSceneItem[];
+}
+
+const COLLAPSE_THRESHOLD = 150;
+const EXPAND_THRESHOLD = 20;
+
+export default function BehindTheSceneClient({
+  items,
+}: BehindTheSceneClientProps) {
+  const params = useParams();
+  const schoolId = Array.isArray(params.schoolId)
+    ? params.schoolId[0]
+    : params.schoolId;
+  const exhibitionId = Array.isArray(params.exhibitionId)
+    ? params.exhibitionId[0]
+    : params.exhibitionId;
+
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const y = window.scrollY;
+      setIsScrolled((prev) => {
+        if (!prev && y > COLLAPSE_THRESHOLD) return true;
+        if (prev && y < EXPAND_THRESHOLD) return false;
+        return prev;
+      });
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const filtered = items.filter(
+    (item) =>
+      !searchQuery ||
+      item.title.includes(searchQuery) ||
+      item.author.includes(searchQuery),
+  );
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <div className="sticky top-0 z-10 bg-normal">
+        <Header />
+
+        {/* 스크롤 전에만 보이는 타이틀 + 서브타이틀 */}
+        <div
+          className={`px-4 overflow-hidden transition-all duration-200 mb-3 ${
+            isScrolled ? "max-h-0 opacity-0" : "max-h-32 opacity-100"
+          }`}
+        >
+          <Title title="Behind The Scene" />
+          <p className="text-body2 text-light">
+            작품의 제작 과정을 확인할 수 있습니다.
+          </p>
+        </div>
+
+        {/* 검색바 */}
+        <div className="px-4 pb-6">
+          <SearchBar
+            placeholder="제목 혹은 작가명을 검색해요."
+            value={searchQuery}
+            onChange={setSearchQuery}
+          />
+        </div>
+      </div>
+
+      {/* 카드 목록 */}
+      <section className="flex flex-col flex-1 px-4 pt-4 pb-6">
+        {filtered.length > 0 ? (
+          <ListCardGrid
+            items={filtered}
+            getHref={(item) =>
+              `/${schoolId}/exhibition/${exhibitionId}/bts/${item.id}`
+            }
+            className="gap-y-10"
+          />
+        ) : (
+          <EmptyState
+            searchQuery={searchQuery}
+            message="등록된 Behind The Scene이 없어요."
+          />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/_mocks/behind-the-scene.ts
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/_mocks/behind-the-scene.ts
@@ -1,0 +1,33 @@
+export interface BehindTheSceneItem {
+	id: number;
+	imageUrl: string;
+	title: string;
+	author: string;
+}
+
+export const MOCK_BEHIND_THE_SCENE: BehindTheSceneItem[] = [
+	{
+		id: 1,
+		imageUrl: "/images/bts/bts1.png",
+		title: "내 졸업 전시 이야기",
+		author: "배주현",
+	},
+	{
+		id: 2,
+		imageUrl: "/images/bts/bts1.png",
+		title: "푸른 색의 미학",
+		author: "배주현",
+	},
+	{
+		id: 3,
+		imageUrl: "/images/bts/bts1.png",
+		title: "내가 흙을 사랑하는 이유",
+		author: "강슬기",
+	},
+	{
+		id: 4,
+		imageUrl: "/images/bts/bts1.png",
+		title: "작업실에서의 하루",
+		author: "김민준",
+	},
+];

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/page.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/page.tsx
@@ -1,5 +1,5 @@
-import { MOCK_BEHIND_THE_SCENE } from "./_mocks/behind-the-scene";
 import BehindTheSceneClient from "./_components/BehindTheSceneClient";
+import { MOCK_BEHIND_THE_SCENE } from "./_mocks/behind-the-scene";
 
 export default function BtsPage() {
 	return <BehindTheSceneClient items={MOCK_BEHIND_THE_SCENE} />;

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/page.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/bts/page.tsx
@@ -1,0 +1,6 @@
+import { MOCK_BEHIND_THE_SCENE } from "./_mocks/behind-the-scene";
+import BehindTheSceneClient from "./_components/BehindTheSceneClient";
+
+export default function BtsPage() {
+	return <BehindTheSceneClient items={MOCK_BEHIND_THE_SCENE} />;
+}

--- a/apps/client/components/common/Card/Card.types.ts
+++ b/apps/client/components/common/Card/Card.types.ts
@@ -2,7 +2,7 @@ export interface CardItem {
 	id: number;
 	imageUrl: string;
 	title: string;
-	category: string;
+	category?: string;
 	author: string;
 }
 
@@ -12,4 +12,5 @@ export interface CardGridProps {
 	items: CardItem[];
 	limit?: number;
 	getHref?: (item: CardItem) => string;
+	className?: string;
 }

--- a/apps/client/components/common/Card/ListCard/ListCard.tsx
+++ b/apps/client/components/common/Card/ListCard/ListCard.tsx
@@ -10,7 +10,8 @@ export const ListCard = ({ imageUrl, title, category, author }: CardProps) => {
 			<div className={s.info}>
 				<h3 className={s.title}>{title}</h3>
 				<div className={s.detail}>
-					<p className={s.author}>{author}</p> · <p className={s.category}>{category}</p>
+					<p className={s.author}>{author}</p>
+					{category && <> · <p className={s.category}>{category}</p></>}
 				</div>
 			</div>
 		</article>

--- a/apps/client/components/common/Card/ListCard/ListCard.tsx
+++ b/apps/client/components/common/Card/ListCard/ListCard.tsx
@@ -11,7 +11,12 @@ export const ListCard = ({ imageUrl, title, category, author }: CardProps) => {
 				<h3 className={s.title}>{title}</h3>
 				<div className={s.detail}>
 					<p className={s.author}>{author}</p>
-					{category && <> · <p className={s.category}>{category}</p></>}
+					{category && (
+						<>
+							{" "}
+							· <p className={s.category}>{category}</p>
+						</>
+					)}
 				</div>
 			</div>
 		</article>

--- a/apps/client/components/common/Card/ListCard/ListCardGrid.tsx
+++ b/apps/client/components/common/Card/ListCard/ListCardGrid.tsx
@@ -1,14 +1,21 @@
+import Link from "next/link";
 import type { CardGridProps } from "../Card.types";
 import { ListCard } from "./ListCard";
 
-export const ListCardGrid = ({ items, limit }: CardGridProps) => {
+export const ListCardGrid = ({ items, limit, getHref, className }: CardGridProps) => {
 	const displayedItems = limit ? items.slice(0, limit) : items;
 
 	return (
-		<div className="flex flex-col gap-y-6 w-full">
-			{displayedItems.map((item) => (
-				<ListCard key={item.id} {...item} />
-			))}
+		<div className={`flex flex-col gap-y-6 w-full ${className ?? ""}`}>
+			{displayedItems.map((item) =>
+				getHref ? (
+					<Link key={item.id} href={getHref(item)}>
+						<ListCard {...item} />
+					</Link>
+				) : (
+					<ListCard key={item.id} {...item} />
+				),
+			)}
 		</div>
 	);
 };

--- a/apps/client/components/common/CollapsingHeader/CollapsingHeader.tsx
+++ b/apps/client/components/common/CollapsingHeader/CollapsingHeader.tsx
@@ -14,7 +14,8 @@ interface CollapsingHeaderProps {
 	children?: React.ReactNode;
 }
 
-const SCROLL_THRESHOLD = 10;
+const COLLAPSE_THRESHOLD = 150;
+const EXPAND_THRESHOLD = 20;
 
 export const CollapsingHeader = ({
 	title,
@@ -26,7 +27,14 @@ export const CollapsingHeader = ({
 	const [isScrolled, setIsScrolled] = useState(false);
 
 	useEffect(() => {
-		const handleScroll = () => setIsScrolled(window.scrollY > SCROLL_THRESHOLD);
+		const handleScroll = () => {
+			const y = window.scrollY;
+			setIsScrolled((prev) => {
+				if (!prev && y > COLLAPSE_THRESHOLD) return true;
+				if (prev && y < EXPAND_THRESHOLD) return false;
+				return prev;
+			});
+		};
 		window.addEventListener("scroll", handleScroll, { passive: true });
 		return () => window.removeEventListener("scroll", handleScroll);
 	}, []);

--- a/apps/client/components/common/Footer/SchoolFooter.tsx
+++ b/apps/client/components/common/Footer/SchoolFooter.tsx
@@ -1,50 +1,45 @@
 import Image from "next/image";
 
 interface SchoolFooterProps {
-  logoSrc?: string;
-  title: string;
-  department: string;
-  address: string;
-  addressDetail: string;
-  email: string;
-  copyright: string;
+	logoSrc?: string;
+	title: string;
+	department: string;
+	address: string;
+	addressDetail: string;
+	email: string;
+	copyright: string;
 }
 
 export default function SchoolFooter({
-  logoSrc,
-  title,
-  department,
-  address,
-  addressDetail,
-  email,
-  copyright,
+	logoSrc,
+	title,
+	department,
+	address,
+	addressDetail,
+	email,
+	copyright,
 }: SchoolFooterProps) {
-  return (
-    <footer className="w-full pt-6 pb-8 flex flex-col mt-12 bg-fg-lighter">
-      <div className="flex flex-col px-4">
-        <div className="flex flex-col gap-1">
-          <h3 className="text-body1-bold text-light">{title}</h3>
-          <div className="h-5 w-full" />
-          <p className="text-body2 text-lighter">{department}</p>
-          <div>
-            <p className="text-body2 text-lighter">{address}</p>
-            <p className="text-body2 text-lighter">{addressDetail}</p>
-          </div>
-          <p className="text-body2 text-lighter">{email}</p>
-        </div>
-        <div className="h-3 w-full" />
-        <p className="text-lightest text-body3-bold">
-          {copyright} <br />
-          All Rights reserved.
-        </p>
-        <div className="h-7 w-full" />
-        <Image
-          src={logoSrc || "/images/logo.svg"}
-          alt={`${title} Logo`}
-          width={60}
-          height={18}
-        />
-      </div>
-    </footer>
-  );
+	return (
+		<footer className="w-full pt-6 pb-8 flex flex-col mt-12 bg-fg-lighter">
+			<div className="flex flex-col px-4">
+				<div className="flex flex-col gap-1">
+					<h3 className="text-body1-bold text-light">{title}</h3>
+					<div className="h-5 w-full" />
+					<p className="text-body2 text-lighter">{department}</p>
+					<div>
+						<p className="text-body2 text-lighter">{address}</p>
+						<p className="text-body2 text-lighter">{addressDetail}</p>
+					</div>
+					<p className="text-body2 text-lighter">{email}</p>
+				</div>
+				<div className="h-3 w-full" />
+				<p className="text-lightest text-body3-bold">
+					{copyright} <br />
+					All Rights reserved.
+				</p>
+				<div className="h-7 w-full" />
+				<Image src={logoSrc || "/images/logo.svg"} alt={`${title} Logo`} width={60} height={18} />
+			</div>
+		</footer>
+	);
 }

--- a/apps/client/components/common/Footer/SchoolFooter.tsx
+++ b/apps/client/components/common/Footer/SchoolFooter.tsx
@@ -1,45 +1,50 @@
 import Image from "next/image";
 
 interface SchoolFooterProps {
-	logoSrc?: string;
-	title: string;
-	department: string;
-	address: string;
-	addressDetail: string;
-	email: string;
-	copyright: string;
+  logoSrc?: string;
+  title: string;
+  department: string;
+  address: string;
+  addressDetail: string;
+  email: string;
+  copyright: string;
 }
 
 export default function SchoolFooter({
-	logoSrc,
-	title,
-	department,
-	address,
-	addressDetail,
-	email,
-	copyright,
+  logoSrc,
+  title,
+  department,
+  address,
+  addressDetail,
+  email,
+  copyright,
 }: SchoolFooterProps) {
-	return (
-		<footer className="w-full pt-12 pb-24 flex flex-col mt-12 bg-fg-lighter">
-			<div className="flex flex-col px-4">
-				<div className="flex flex-col gap-1">
-					<h3 className="text-body1-bold text-light">{title}</h3>
-					<div className="h-5 w-full" />
-					<p className="text-body2 text-lighter">{department}</p>
-					<div>
-						<p className="text-body2 text-lighter">{address}</p>
-						<p className="text-body2 text-lighter">{addressDetail}</p>
-					</div>
-					<p className="text-body2 text-lighter">{email}</p>
-				</div>
-				<div className="h-3 w-full" />
-				<p className="text-lightest text-body3-bold">
-					{copyright} <br />
-					All Rights reserved.
-				</p>
-				<div className="h-7 w-full" />
-				<Image src={logoSrc || "/images/logo.svg"} alt={`${title} Logo`} width={60} height={18} />
-			</div>
-		</footer>
-	);
+  return (
+    <footer className="w-full pt-6 pb-8 flex flex-col mt-12 bg-fg-lighter">
+      <div className="flex flex-col px-4">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-body1-bold text-light">{title}</h3>
+          <div className="h-5 w-full" />
+          <p className="text-body2 text-lighter">{department}</p>
+          <div>
+            <p className="text-body2 text-lighter">{address}</p>
+            <p className="text-body2 text-lighter">{addressDetail}</p>
+          </div>
+          <p className="text-body2 text-lighter">{email}</p>
+        </div>
+        <div className="h-3 w-full" />
+        <p className="text-lightest text-body3-bold">
+          {copyright} <br />
+          All Rights reserved.
+        </p>
+        <div className="h-7 w-full" />
+        <Image
+          src={logoSrc || "/images/logo.svg"}
+          alt={`${title} Logo`}
+          width={60}
+          height={18}
+        />
+      </div>
+    </footer>
+  );
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
 
BTS(Behind The Scene) 목록 페이지 구현

  - `[schoolId]/exhibition/[exhibitionId]/bts` 경로에 BTS 목록 페이지 추가
  - 스크롤 시 타이틀+서브타이틀이 접히는 CollapsingHeader 레이아웃 적용
  - 제목/작가명 검색 기능 구현
  - Mock 데이터 연결 (API 연동 전)

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
  - `schoolId` URL 구조는 추후 API 연동 시 리팩토링 예정
  - 스크롤 흔들림 방지를 위해 Hysteresis 방식 적용 (접힘: 150px / 펼침: 20px)
  -   ListCardGrid 공통 컴포넌트 개선
     - getHref prop 추가로 카드 클릭 시 링크 이동 지원
     - className prop 추가로 gap 등 스타일 커스텀 가능
     - CardItem.category optional 처리 → category 없는 BTS 아이템에도 재사용 가능

## 📸 스크린샷

| 구현 내용 |             540             |            375px            |            320px            |
| :-------: | :-------------------------: | :-------------------------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/adcdc65e-a0f1-465e-b1cb-51647476670b" width ="250"> | <img src = "https://github.com/user-attachments/assets/2e1f3c7d-2dbb-4334-952a-3c2bc7c5f4e2" width ="250"> | <img src = "https://github.com/user-attachments/assets/bbe3765e-48ef-49c0-8d07-24773af8a261" width ="250"> |

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

 **스크롤 Hysteresis**

헤더 접힘 시 레이아웃이 줄어들어 scrollY가 변동하는 피드백 루프를 방지하기 위해 접힐 때와 펼쳐질 때 다른 threshold를 사용합니다.

  ```typescript
  const COLLAPSE_THRESHOLD = 150;
  const EXPAND_THRESHOLD = 20;

  setIsScrolled((prev) => {
    if (!prev && y > COLLAPSE_THRESHOLD) return true;
    if (prev && y < EXPAND_THRESHOLD) return false;
    return prev;
  });

```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #이슈번호
- closed #30 