### PR TITLE
feat: useScrollSpy 훅 분리 및 전시물목록,상세 페이지에 ScrollTabBar 컴포넌트 사용

### DIFF
--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
@@ -1,7 +1,10 @@
 "use client";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 import type { MOCK_ARTWORK_DETAIL } from "@/app/[schoolId]/exhibition/[exhibitionId]/artwork/_mocks/artworkDetail";
+import { Divider } from "@/components/common/Divider/Divider";
+import { ScrollTabBar } from "@/components/common/ScrollTabBar/ScrollTabBar";
+import { useScrollSpy } from "@/components/common/ScrollTabBar/useScrollSpy";
 import { Header } from "../../../_components/Header";
 import { ArtistSection } from "../_components/ArtistSection";
 import { BtsSection } from "../_components/BtsSection";
@@ -19,11 +22,21 @@ export function ArtworkDetailClient({
 	data: typeof MOCK_ARTWORK_DETAIL;
 	schoolId: string;
 }) {
-	const router = useRouter();
+	// ScrollTabBar 탭 목록 [ 작품 소개, 작가 소개, 비하인드(선택) ]
+	const TABS = useMemo(() => {
+		const base = [
+			{ id: "detail", label: "작품 소개" },
+			{ id: "artist", label: "작가 소개" },
+		];
+		if (data.bts?.length) base.push({ id: "behind", label: "비하인드" });
+		return base;
+	}, [data.bts]);
+	const { activeTab, handleTabClick, sectionRefs } = useScrollSpy(TABS.map((t) => t.id));
 
 	return (
 		<div className="flex flex-col">
-			<Header variant="back" onBackClick={() => router.back()} />
+			<Header variant="back" />
+
 			{/* 대표 이미지 */}
 			<div className="relative aspect-video w-full">
 				<Image src={data.image} alt={data.title} fill className="object-cover" priority />
@@ -33,18 +46,41 @@ export function ArtworkDetailClient({
 			{/* 작품 위치 섹션 */}
 			<LocationSection locationImageUrl={data.locationImageUrl} />
 			{/* 상세 소개 섹션 */}
-			<DescriptionSection content={data.description} exhibitionTitle={data.exhibitionTitle} />
+			<section
+				ref={(el) => {
+					sectionRefs.detail.current = el;
+				}}
+			>
+				<DescriptionSection content={data.description} />
+			</section>
 			{/* 상세 이미지 섹션*/}
 			<PhotoSection images={data.detailImages} purchaseUrl={data.purchaseUrl} />
 			{/* 참여자 섹션 */}
-			<ArtistSection authors={data.authors} schoolId={schoolId} />
-			{/* TODO : 머지 후 Divider import */}
-			{/* BTS 섹션 */}
-			<BtsSection bts={data.bts} />
+			<section
+				ref={(el) => {
+					sectionRefs.artist.current = el;
+				}}
+			>
+				<ArtistSection authors={data.authors} schoolId={schoolId} />
+			</section>
+			<Divider />
+			{/* BTS 섹션 - 선택값 */}
+			{data.bts?.length > 0 && (
+				<section
+					ref={(el) => {
+						sectionRefs.behind.current = el;
+					}}
+				>
+					<BtsSection bts={data.bts} />
+				</section>
+			)}
 			{/* 동일한 카테고리 작품 섹션 */}
 			<RelatedSection category={data.category} />
 			{/* 둘러보기 섹션 */}
 			<PostNavigationSection prevArtwork={data.prevArtwork} nextArtwork={data.nextArtwork} />
+
+			{/* 하단 스크롤탭바 */}
+			<ScrollTabBar tabs={TABS} activeTab={activeTab} onTabClick={handleTabClick} />
 		</div>
 	);
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/BtsSection.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/BtsSection.tsx
@@ -1,8 +1,5 @@
-import Image from "next/image";
+import { BTSCardGrid } from "@/components/common/Card/BTSCard/BTSCardGrid";
 import { Title } from "@/components/common/Title/Title";
-
-// TODO : 머지 후 BTSCardGrid 컴포넌트 import 예정
-// import { BTSCardGrid, BTSCardGridProps } from "../BTSCardGrid";
 
 interface BtsSectionProps {
 	bts: { id: number; title: string; author: string; imageUrl: string }[];
@@ -13,26 +10,7 @@ export const BtsSection = ({ bts }: BtsSectionProps) => {
 	return (
 		<section className="flex flex-col px-4 pb-6">
 			<Title title="Behind The Scene" />
-			{/* 머지 후 BTS 카드 아래와 같이 연결 예정 */}
-			{/* <BTSCardGrid items={bts} /> */}
-
-			{/* 임시 예시입니다 */}
-			<div className="flex flex-col gap-4">
-				{bts.map((item) => (
-					<div key={item.id} className="flex items-center gap-4">
-						<div className="relative w-16 h-16">
-							<Image src={item.imageUrl} alt={item.title} fill className="object-cover" />
-							<div className="flex h-full items-center justify-center text-[10px] text-gray-400">
-								BTS
-							</div>
-						</div>
-						<div className="flex flex-col">
-							<span className="text-body1-bold">{item.title}</span>
-							<span className="text-body2">{item.author}</span>
-						</div>
-					</div>
-				))}
-			</div>
+			<BTSCardGrid items={bts} />
 		</section>
 	);
 };

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/BtsSection.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/BtsSection.tsx
@@ -1,9 +1,8 @@
-import { BTSCardGrid } from "@/components/common/Card/BTSCard/BTSCardGrid";
+import { BTSCardGrid, type BTSCardGridProps } from "@/components/common/Card/BTSCard/BTSCardGrid";
 import { Title } from "@/components/common/Title/Title";
 
 interface BtsSectionProps {
-	bts: { id: number; title: string; author: string; imageUrl: string }[];
-	// 		bts: BTSCardGridProps["items"]
+	bts: BTSCardGridProps["items"]
 }
 
 export const BtsSection = ({ bts }: BtsSectionProps) => {

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/BtsSection.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/BtsSection.tsx
@@ -2,7 +2,7 @@ import { BTSCardGrid, type BTSCardGridProps } from "@/components/common/Card/BTS
 import { Title } from "@/components/common/Title/Title";
 
 interface BtsSectionProps {
-	bts: BTSCardGridProps["items"]
+	bts: BTSCardGridProps["items"];
 }
 
 export const BtsSection = ({ bts }: BtsSectionProps) => {

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/DescriptionSection.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/[artworkId]/_components/DescriptionSection.tsx
@@ -1,14 +1,8 @@
 import { Title } from "@/components/common/Title/Title";
 
-export const DescriptionSection = ({
-	content,
-	exhibitionTitle,
-}: {
-	content: string;
-	exhibitionTitle: string;
-}) => (
+export const DescriptionSection = ({ content }: { content: string }) => (
 	<section className="flex flex-col px-4 pb-6">
-		<Title title={exhibitionTitle} />
+		<Title title="작품 소개" />
 		<p className="whitespace-pre-wrap leading-relaxed text-body1">{content}</p>
 	</section>
 );

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
@@ -92,7 +92,8 @@ export function ArtworkListSection({ sectionRefs }: ArtworkListSectionProps) {
 							key={zone}
 							ref={(el) => {
 								if (sectionRefs[zone]) {
-									(sectionRefs[zone] as unknown as React.RefObject<HTMLElement | null>).current = el;
+									(sectionRefs[zone] as unknown as React.RefObject<HTMLElement | null>).current =
+										el;
 								}
 							}}
 						>

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
@@ -14,8 +14,8 @@ import Filter from "./components/Filter";
 import { ListIcon } from "./components/ListIcon";
 
 interface ArtworkListSectionProps {
-	refs: React.RefObject<HTMLDivElement | null>[];
-	refOffset: number;
+	sectionRefs: Record<string, React.RefObject<HTMLElement | null>>;
+	grouped: Record<string, Artwork[]>;
 }
 
 // [임시] Artwork → CardItem 변환
@@ -53,16 +53,17 @@ const ViewToggle = ({
 	</div>
 );
 
-export function ArtworkListSection({ refs, refOffset }: ArtworkListSectionProps) {
+export function ArtworkListSection({ sectionRefs }: ArtworkListSectionProps) {
 	const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
 	const { ref: titleRef, isVisible: isTitleVisible } = useIntersectionObserver();
+
 	const { selected, setSelected, categories, grouped } = useArtworkFilter();
 
 	const zones = Object.keys(grouped);
 	const isMultiZone = zones.length > 1;
 
 	return (
-		<section className="flex flex-col pb-6">
+		<section className="flex flex-col">
 			{/* 스크롤 전 (Title + 토글버튼) */}
 			<div ref={titleRef} className="flex justify-between items-center px-4">
 				<Title title="작품 목록" />
@@ -84,10 +85,17 @@ export function ArtworkListSection({ refs, refOffset }: ArtworkListSectionProps)
 			구역이 2개 이상일 경우 구역 Title과 함께 작품 목록을
 			렌더링 합니다 */}
 			<div className="flex flex-col px-4 gap-6">
-				{zones.map((zone, index) => {
+				{zones.map((zone) => {
 					const items = grouped[zone].map(toCardItem);
 					return (
-						<div key={zone} ref={refs[index + refOffset]}>
+						<div
+							key={zone}
+							ref={(el) => {
+								if (sectionRefs[zone]) {
+									(sectionRefs[zone] as any).current = el;
+								}
+							}}
+						>
 							{isMultiZone && <Title title={zone} />}
 							{items.length === 0 ? (
 								<EmptyState

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
@@ -92,7 +92,7 @@ export function ArtworkListSection({ sectionRefs }: ArtworkListSectionProps) {
 							key={zone}
 							ref={(el) => {
 								if (sectionRefs[zone]) {
-									(sectionRefs[zone] as any).current = el;
+									(sectionRefs[zone] as unknown as React.RefObject<HTMLElement | null>).current = el;
 								}
 							}}
 						>

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/ArtworksClient.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/ArtworksClient.tsx
@@ -1,24 +1,40 @@
 "use client";
-import { BottomTabBar } from "@/components/common/BottomTabBar/BottomTabBar";
-import { useBottomTabBar } from "@/components/common/BottomTabBar/useBottomTabBar";
+import { ScrollTabBar } from "@/components/common/ScrollTabBar/ScrollTabBar";
+import { useScrollSpy } from "@/components/common/ScrollTabBar/useScrollSpy";
 import { useArtworkFilter } from "../hooks/useArtworkFilter";
 import { ArtworkListSection } from "./ArtworkListSection";
 import { GuideSection } from "./GuideSection";
 
 export function ArtworksClient({ guideImages }: { guideImages: string[] }) {
 	const hasGuide = guideImages.length > 0;
-	const { grouped } = useArtworkFilter();
-	const zones = Object.keys(grouped);
+	const { grouped } = useArtworkFilter(); // TODO : 백에서 구역 그룹화되어 내려오는지 확인
 
-	const labels = [...(hasGuide ? ["관람 안내"] : []), ...zones];
-
-	const { tabs, activeIndex, refs } = useBottomTabBar(labels);
+	// ScrollTabBar 탭 [관람 안내(선택값), zone(고유값)]
+	const TABS = [
+		...(hasGuide ? [{ id: "guide", label: "관람 안내" }] : []),
+		...Object.keys(grouped).map((zone) => ({
+			id: zone,
+			label: zone,
+		})),
+	];
+	const { activeTab, handleTabClick, sectionRefs } = useScrollSpy(
+		TABS.map((t) => t.id),
+		142,
+	);
 
 	return (
 		<>
-			{hasGuide && <GuideSection guideImages={guideImages} sectionRef={refs[0]} />}
-			<ArtworkListSection refs={refs} refOffset={hasGuide ? 1 : 0} />
-			<BottomTabBar tabs={tabs} activeIndex={activeIndex} scrollOffset={147} />
+			{hasGuide && (
+				<div
+					ref={(el) => {
+						if (sectionRefs.guide) sectionRefs.guide.current = el;
+					}}
+				>
+					<GuideSection guideImages={guideImages} />
+				</div>
+			)}
+			<ArtworkListSection grouped={grouped} sectionRefs={sectionRefs} />
+			<ScrollTabBar tabs={TABS} activeTab={activeTab} onTabClick={handleTabClick} />
 		</>
 	);
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/components/EmptyState.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artwork/_components/components/EmptyState.tsx
@@ -1,0 +1,13 @@
+interface EmptyStateProps {
+	message?: string;
+}
+
+export function EmptyState({
+	message = "선택한 카테고리에 해당되는 작품이 없어요.",
+}: EmptyStateProps) {
+	return (
+		<div className="flex flex-col justify-center items-center w-full pb-16 pt-10 px-2.5">
+			<p className="text-center text-body1 text-lightest max-w-43">{message}</p>
+		</div>
+	);
+}

--- a/apps/client/components/common/Card/BTSCard/BTSCardGrid.tsx
+++ b/apps/client/components/common/Card/BTSCard/BTSCardGrid.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { BTSCard } from "./BTSCard";
 
-interface BTSCardGridProps {
+export interface BTSCardGridProps {
 	items: { id: number; title: string; author: string; imageUrl: string }[];
 	getHref?: (item: { id: number }) => string;
 }

--- a/apps/client/components/common/ScrollTabBar/useScrollSpy.ts
+++ b/apps/client/components/common/ScrollTabBar/useScrollSpy.ts
@@ -1,0 +1,64 @@
+/**
+ * scrollTabBar 컴포넌트에서 반복되는 로직을 분리하기 위한 커스텀 훅입니다.
+ *
+ * [핵심 반복 로직]
+ * 1. 각 섹션를 담을 id 배열 생성
+ * 2. 각 섹션에 refs 할당
+ * 3. 현재 활성화된 activeTab을 반환
+ *
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+// 기본 offset : 44px (헤더높이)
+export const useScrollSpy = (tabIds: string[], offset: number = 44) => {
+	const [activeTab, setActiveTab] = useState(tabIds[0]);
+
+	// 1. 각 섹션(tabId)에 대응하는 객체 배열 생성
+	// 2. 각 객체에 refs를 담음 (할당)
+	// tabIds가 바뀔 때만 refs를 재생성하도록 useMemo 활용
+	const sectionRefs = useMemo(() => {
+		return tabIds.reduce(
+			(acc, id) => {
+				acc[id] = { current: null };
+				return acc;
+			},
+			{} as Record<string, React.RefObject<HTMLElement | null>>,
+		);
+	}, [tabIds]);
+
+	// 경우1 : 탭을 클릭하여 해당 섹션으로 이동
+	const handleTabClick = (tabId: string) => {
+		const ref = sectionRefs[tabId];
+		if (ref?.current) {
+			const top = ref.current.getBoundingClientRect().top + window.scrollY - offset;
+			window.scrollTo({ top, behavior: "smooth" });
+			setActiveTab(tabId);
+		}
+	};
+
+	// 경우2 : 스크롤을 화면이 감지하여 활성화탭을 변경
+	useEffect(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						const matchedId = Object.keys(sectionRefs).find(
+							(id) => sectionRefs[id].current === entry.target,
+						);
+						if (matchedId) setActiveTab(matchedId);
+					}
+				});
+			},
+			{ rootMargin: `-${offset + 10}px 0px -70% 0px`, threshold: 0 },
+		);
+
+		Object.values(sectionRefs).forEach((ref) => {
+			if (ref.current) observer.observe(ref.current);
+		});
+
+		return () => observer.disconnect();
+	}, [sectionRefs, offset]);
+
+	return { activeTab, handleTabClick, sectionRefs };
+};


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

- useScrollSpy 커스텀훅 추가 (ScrollTabBar 활용 목적)
- `ArtworkListSection`에 ScrollTabBar 컴포넌트 재사용으로 리팩토링
- `ArtworkDetailClient`에 ScrollTabBar 컴포넌트 추가 (기존 누락)
- `BTSCardGrid.tsx`에서 타입 export (타입 재사용하여 타입 일관성 확보를 위함)

## 💡 참고 사항



## 📸 스크린샷

<img width="563" height="92" alt="image" src="https://github.com/user-attachments/assets/f02c41ff-a6cb-4b3a-b483-d5e30eee78ad" />

## 🖥️ 주요 코드 설명

`useScrollSpy.ts`

#### 개요
- 찬주언니가 만들어준 ScrollTabBar 컴포넌트를 여러 곳에서 쉽게 재사용하기 위한 목적으로, 반복되는 핵심 로직을 담은 useScrollSpy.ts 커스텀 훅을 분리했습니다.
- 섹션의 순서가 바뀌거나 동적으로 추가/삭제되어도, 인덱스가 아닌 고유 id를 기반으로 Ref를 매핑하므로 탭 동작이 안전합니다.

#### 핵심 로직
1. 각 섹션을 식별할 고유 id 배열 생성
2. 각 섹션 DOM 요소에 refs 할당 및 관리
3. 현재 활성화된 activeTab을 반환 (Tab은 스크롤 위치 및 탭 클릭 인터랙션에 따라 활성화됨)

#### 참고사항
- **가변 Offset 대응 가능** : 상단 고정 부분을 제외하고 스크롤 되기 위해, offset을 설정할 수 있습니다. (기본 : 헤더 높이 44px)
- **스크롤 위치 계산 시 대상 요소를 유연하게 바인딩** : useScrollSpy는 HTML 내 DOM 요소들에 접근하여 필요한 섹션의 요소를 데려와 sectionRefs에 담습니다. 이때 담길 수 있는 섹션의 요소 타입이 상이할 수 있으므로, 데이터 일관성과 확장성을 고려하여 `as unknown as React.RefObject<HTMLElement | null>`을 통해 요소 타입과 관계없이 스크롤 위치를 계산할 수 있는 일반적인 HTML 요소로 취급합니다. 

```
import { useEffect, useMemo, useState } from "react";

// 기본 offset : 44px (헤더높이)
export const useScrollSpy = (tabIds: string[], offset: number = 44) => {
	const [activeTab, setActiveTab] = useState(tabIds[0]);

	// 1. 각 섹션(tabId)에 대응하는 객체 배열 생성
	// 2. 각 객체에 refs를 담음 (할당)
	// tabIds가 바뀔 때만 refs를 재생성하도록 useMemo 활용
	const sectionRefs = useMemo(() => {
		return tabIds.reduce(
			(acc, id) => {
				acc[id] = { current: null };
				return acc;
			},
			{} as Record<string, React.RefObject<HTMLElement | null>>,
		);
	}, [tabIds]);

	// 경우1 : 탭을 클릭하여 해당 섹션으로 이동
	const handleTabClick = (tabId: string) => {
		const ref = sectionRefs[tabId];
		if (ref?.current) {
			const top = ref.current.getBoundingClientRect().top + window.scrollY - offset;
			window.scrollTo({ top, behavior: "smooth" });
			setActiveTab(tabId);
		}
	};

	// 경우2 : 스크롤을 화면이 감지하여 활성화탭을 변경
	useEffect(() => {
		const observer = new IntersectionObserver(
			(entries) => {
				entries.forEach((entry) => {
					if (entry.isIntersecting) {
						const matchedId = Object.keys(sectionRefs).find(
							(id) => sectionRefs[id].current === entry.target,
						);
						if (matchedId) setActiveTab(matchedId);
					}
				});
			},
			{ rootMargin: `-${offset + 10}px 0px -70% 0px`, threshold: 0 },
		);

		Object.values(sectionRefs).forEach((ref) => {
			if (ref.current) observer.observe(ref.current);
		});

		return () => observer.disconnect();
	}, [sectionRefs, offset]);

        // 현재 활성화된 탭, 탭 클릭 핸들러, 각 섹션에 부여되는 refs 를 반환
	return { activeTab, handleTabClick, sectionRefs };
};
```
#### 사용 방법
- 고유 id를 기반으로 섹션을 인식하는 것이 핵심입니다.
- 사용하려는 페이지에서 id 와 그에 해당하는 탭 라벨을 지정하여 섹션을 활성화합니다.

1. 사용하려는 페이지에서 다음처럼 탭 목록을 정의 (id-라벨 연결)
```
// ScrollTabBar 탭 목록 [ 작품 소개, 작가 소개, 비하인드(선택) ]
	const TABS = useMemo(() => {
		const base = [
			{ id: "detail", label: "작품 소개" },
			{ id: "artist", label: "작가 소개" },
		];
		if (data.bts?.length) base.push({ id: "behind", label: "비하인드" });
		return base;
	}, [data.bts]);
// 훅 호출 (id 배열 전달)
	const { activeTab, handleTabClick, sectionRefs } = useScrollSpy(TABS.map((t) => t.id));
```
2. 각 섹션에 Ref 할당 : 필요한 섹션에 해당하는 컴포넌트 등에 감싸면 됩니다.
```
<section ref={(el) => { sectionRefs.detail.current = el; }}>
	<DescriptionSection content={data.description} />
</section>
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #44
