### PR TITLE
[Feat] 전시회 OG 태그 동적 설정

### DIFF
--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/_api/getExhibitionMeta.ts
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/_api/getExhibitionMeta.ts
@@ -6,10 +6,9 @@ interface ExhibitionMeta {
 }
 
 export async function getExhibitionMeta(exhibitionId: string): Promise<ExhibitionMeta | null> {
-	const res = await fetch(
-		`${process.env.NEXT_PUBLIC_API_URL}/exhibition/${exhibitionId}/meta`,
-		{ next: { revalidate: 3600 } },
-	);
+	const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/exhibition/${exhibitionId}/meta`, {
+		next: { revalidate: 3600 },
+	});
 
 	if (!res.ok) return null;
 	return res.json();

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/_api/getExhibitionMeta.ts
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/_api/getExhibitionMeta.ts
@@ -1,0 +1,16 @@
+interface ExhibitionMeta {
+	id: string;
+	title: string;
+	description: string | null;
+	image: string | null;
+}
+
+export async function getExhibitionMeta(exhibitionId: string): Promise<ExhibitionMeta | null> {
+	const res = await fetch(
+		`${process.env.NEXT_PUBLIC_API_URL}/exhibition/${exhibitionId}/meta`,
+		{ next: { revalidate: 3600 } },
+	);
+
+	if (!res.ok) return null;
+	return res.json();
+}

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/page.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/page.tsx
@@ -1,5 +1,7 @@
+import type { Metadata } from "next";
 import Image from "next/image";
 import { MOCK_EXHIBITION_DATA } from "@/constants/exhibition";
+import { getExhibitionMeta } from "./_api/getExhibitionMeta";
 import { ExhibitionDetail } from "./_components/ExhibitionDetailSection";
 import { ExhibitionHost } from "./_components/ExhibitionHostSection";
 import { ExhibitionIntro } from "./_components/ExhibitionIntroSection";
@@ -7,38 +9,60 @@ import { ExhibitionLocation } from "./_components/ExhibitionLocationSection";
 import { Header } from "./_components/Header";
 
 interface ExhibitionDetailPageProps {
-	params: Promise<{ schoolId: string; exhibitionId: string }>;
+  params: Promise<{ schoolId: string; exhibitionId: string }>;
 }
 
-export default async function ExhibitionDetailPage({ params }: ExhibitionDetailPageProps) {
-	const { exhibitionId } = await params;
-	const exhibition = MOCK_EXHIBITION_DATA.find((e) => e.id === exhibitionId);
-	if (!exhibition) {
-		return <div>전시회를 찾을 수 없습니다.</div>;
-	}
+export async function generateMetadata({
+  params,
+}: ExhibitionDetailPageProps): Promise<Metadata> {
+  const { exhibitionId } = await params;
+  const meta = await getExhibitionMeta(exhibitionId);
 
-	return (
-		<main>
-			<Header />
-			{/* 대표 이미지 */}
-			<div className="relative w-full aspect-3/4">
-				<Image
-					src={exhibition.thumbnailUrl}
-					alt={exhibition.title}
-					fill
-					className="object-cover"
-					priority
-				/>
-			</div>
-			{/* 제목 및 기본 정보 */}
-			<ExhibitionIntro exhibition={exhibition} />
-			{/* 전시 소개 */}
-			<ExhibitionDetail exhibition={exhibition} />
-			{/* TODO : 머지 후 Divider import */}
-			{/* 장소 */}
-			<ExhibitionLocation location={exhibition.location} />
-			{/* 주최 기관 */}
-			<ExhibitionHost hostInfo={exhibition.hostInfo} socialLinks={exhibition.socialLinks} />
-		</main>
-	);
+  return {
+    title: meta?.title,
+    description: meta?.description,
+    openGraph: {
+      title: meta?.title,
+      description: meta?.description ?? undefined,
+      images: meta?.image ? [{ url: meta.image }] : [],
+    },
+  };
+}
+
+export default async function ExhibitionDetailPage({
+  params,
+}: ExhibitionDetailPageProps) {
+  const { exhibitionId } = await params;
+  const exhibition = MOCK_EXHIBITION_DATA.find((e) => e.id === exhibitionId);
+  if (!exhibition) {
+    return <div>전시회를 찾을 수 없습니다.</div>;
+  }
+
+  return (
+    <main>
+      <Header />
+      {/* 대표 이미지 */}
+      <div className="relative w-full aspect-3/4">
+        <Image
+          src={exhibition.thumbnailUrl}
+          alt={exhibition.title}
+          fill
+          className="object-cover"
+          priority
+        />
+      </div>
+      {/* 제목 및 기본 정보 */}
+      <ExhibitionIntro exhibition={exhibition} />
+      {/* 전시 소개 */}
+      <ExhibitionDetail exhibition={exhibition} />
+      {/* TODO : 머지 후 Divider import */}
+      {/* 장소 */}
+      <ExhibitionLocation location={exhibition.location} />
+      {/* 주최 기관 */}
+      <ExhibitionHost
+        hostInfo={exhibition.hostInfo}
+        socialLinks={exhibition.socialLinks}
+      />
+    </main>
+  );
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/page.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/page.tsx
@@ -9,60 +9,53 @@ import { ExhibitionLocation } from "./_components/ExhibitionLocationSection";
 import { Header } from "./_components/Header";
 
 interface ExhibitionDetailPageProps {
-  params: Promise<{ schoolId: string; exhibitionId: string }>;
+	params: Promise<{ schoolId: string; exhibitionId: string }>;
 }
 
-export async function generateMetadata({
-  params,
-}: ExhibitionDetailPageProps): Promise<Metadata> {
-  const { exhibitionId } = await params;
-  const meta = await getExhibitionMeta(exhibitionId);
+export async function generateMetadata({ params }: ExhibitionDetailPageProps): Promise<Metadata> {
+	const { exhibitionId } = await params;
+	const meta = await getExhibitionMeta(exhibitionId);
 
-  return {
-    title: meta?.title,
-    description: meta?.description,
-    openGraph: {
-      title: meta?.title,
-      description: meta?.description ?? undefined,
-      images: meta?.image ? [{ url: meta.image }] : [],
-    },
-  };
+	return {
+		title: meta?.title,
+		description: meta?.description,
+		openGraph: {
+			title: meta?.title,
+			description: meta?.description ?? undefined,
+			images: meta?.image ? [{ url: meta.image }] : [],
+		},
+	};
 }
 
-export default async function ExhibitionDetailPage({
-  params,
-}: ExhibitionDetailPageProps) {
-  const { exhibitionId } = await params;
-  const exhibition = MOCK_EXHIBITION_DATA.find((e) => e.id === exhibitionId);
-  if (!exhibition) {
-    return <div>전시회를 찾을 수 없습니다.</div>;
-  }
+export default async function ExhibitionDetailPage({ params }: ExhibitionDetailPageProps) {
+	const { exhibitionId } = await params;
+	const exhibition = MOCK_EXHIBITION_DATA.find((e) => e.id === exhibitionId);
+	if (!exhibition) {
+		return <div>전시회를 찾을 수 없습니다.</div>;
+	}
 
-  return (
-    <main>
-      <Header />
-      {/* 대표 이미지 */}
-      <div className="relative w-full aspect-3/4">
-        <Image
-          src={exhibition.thumbnailUrl}
-          alt={exhibition.title}
-          fill
-          className="object-cover"
-          priority
-        />
-      </div>
-      {/* 제목 및 기본 정보 */}
-      <ExhibitionIntro exhibition={exhibition} />
-      {/* 전시 소개 */}
-      <ExhibitionDetail exhibition={exhibition} />
-      {/* TODO : 머지 후 Divider import */}
-      {/* 장소 */}
-      <ExhibitionLocation location={exhibition.location} />
-      {/* 주최 기관 */}
-      <ExhibitionHost
-        hostInfo={exhibition.hostInfo}
-        socialLinks={exhibition.socialLinks}
-      />
-    </main>
-  );
+	return (
+		<main>
+			<Header />
+			{/* 대표 이미지 */}
+			<div className="relative w-full aspect-3/4">
+				<Image
+					src={exhibition.thumbnailUrl}
+					alt={exhibition.title}
+					fill
+					className="object-cover"
+					priority
+				/>
+			</div>
+			{/* 제목 및 기본 정보 */}
+			<ExhibitionIntro exhibition={exhibition} />
+			{/* 전시 소개 */}
+			<ExhibitionDetail exhibition={exhibition} />
+			{/* TODO : 머지 후 Divider import */}
+			{/* 장소 */}
+			<ExhibitionLocation location={exhibition.location} />
+			{/* 주최 기관 */}
+			<ExhibitionHost hostInfo={exhibition.hostInfo} socialLinks={exhibition.socialLinks} />
+		</main>
+	);
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

전시회 페이지의 OG 태그를 전시회별로 동적으로 설정했습니다.

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

- API 연동 전이므로 `getExhibitionMeta` 내부는 fetch 구조만 잡아둔 상태입니다.
- Next.js 규칙상 generateMetadata는 page.tsx나 layout.tsx에서만 동작하기에 따로 분리는 안해놓은 상태입니다.


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`generateMetadata`
 
- Next.js App Router의 `generateMetadata`를 사용해 전시회별 title, description, OG 이미지를 동적으로 주입합니다.
- `generateMetadata`와 page 컴포넌트가 동일한 `params`를 `await`해도 Promise 특성상 재실행되지 않습니다.                                                   
- `openGraph.description`은 `null`을 허용하지 않아 `?? undefined`로 변환합니다.

```typescript
  export async function generateMetadata({ params }: ExhibitionDetailPageProps):
   Promise<Metadata> {
    const { exhibitionId } = await params;
    const meta = await getExhibitionMeta(exhibitionId);                         
   
    return {                                                                    
      title: meta?.title,
      description: meta?.description,
      openGraph: {
        title: meta?.title,
        description: meta?.description ?? undefined,
        images: meta?.image ? [{ url: meta.image }] : [],                       
      },
    };                                                                          
  }  
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #43
