### PR TITLE
[Refactor] artist 페이지 동적 렌더링 및 스타일 수정

### DIFF
--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/Navigator.styles.ts
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/Navigator.styles.ts
@@ -1,11 +1,11 @@
 export const navigatorStyles = {
-  wrapper: "flex items-center justify-between py-[10px] w-full",
+	wrapper: "flex items-center justify-between py-[10px] w-full",
 
-  left: "text-body2-bold text-strong",
+	left: "text-body2-bold text-strong",
 
-  right: "flex items-center gap-1 pl-1",
+	right: "flex items-center gap-1 pl-1",
 
-  label: "text-body3-bold text-lightest",
+	label: "text-body3-bold text-lightest",
 
-  icon: "w-6 h-6 object-contain",
+	icon: "w-6 h-6 object-contain",
 };

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/Navigator.styles.ts
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/Navigator.styles.ts
@@ -1,11 +1,11 @@
 export const navigatorStyles = {
-	wrapper: "flex items-center justify-between py-[10px] w-full",
+  wrapper: "flex items-center justify-between py-[10px] w-full",
 
-	left: "text-body2-bold text-strong",
+  left: "text-body2-bold text-strong",
 
-	right: "flex items-center gap-1 pl-1",
+  right: "flex items-center gap-1 pl-1",
 
-	label: "text-body3 text-light",
+  label: "text-body3-bold text-lightest",
 
-	icon: "w-6 h-6 object-contain",
+  icon: "w-6 h-6 object-contain",
 };

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/PostNavigation/PostNavigation.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/PostNavigation/PostNavigation.tsx
@@ -1,44 +1,49 @@
 "use client";
 
-import { Divider } from "../../../../../../../../../components/common/Divider/Divider";
+import { Divider } from "@/components/common/Divider/Divider";
 import { Navigator } from "../Navigator";
 import { postNavigationStyles as s } from "./PostNavigation.styles";
 
 import type { NavItem, PostNavigationProps } from "./PostNavigation.types";
 
 export function PostNavigation({ prevPost, nextPost }: PostNavigationProps) {
-	const navItems: NavItem[] = [
-		prevPost && {
-			label: "이전 작가",
-			artistName: prevPost.title,
-			artistId: String(prevPost.id),
-			direction: "prev",
-		},
-		nextPost && {
-			label: "다음 작가",
-			artistName: nextPost.title,
-			artistId: String(nextPost.id),
-			direction: "next",
-		},
-	].filter(Boolean) as NavItem[];
+  const navItems: NavItem[] = [
+    prevPost && {
+      label: "이전 작가",
+      artistName: prevPost.title,
+      artistId: String(prevPost.id),
+      direction: "prev",
+    },
+    nextPost && {
+      label: "다음 작가",
+      artistName: nextPost.title,
+      artistId: String(nextPost.id),
+      direction: "next",
+    },
+  ].filter(Boolean) as NavItem[];
 
-	if (navItems.length === 0) return null;
+  if (navItems.length === 0) return null;
 
-	return (
-		<section>
-			<Divider spacing="none" thickness="thin" fullBleed={false} color="lighter" />
+  return (
+    <section>
+      <Divider
+        spacing="none"
+        thickness="thin"
+        fullBleed={false}
+        color="lighter"
+      />
 
-			<div className={s.wrapper}>
-				{navItems.map((item, idx) => (
-					<div key={item.artistId}>
-						<Navigator {...item} />
+      <div className={s.wrapper}>
+        {navItems.map((item, idx) => (
+          <div key={item.artistId}>
+            <Navigator {...item} />
 
-						{idx !== navItems.length - 1 && (
-							<Divider spacing="none" thickness="thin" fullBleed={false} />
-						)}
-					</div>
-				))}
-			</div>
-		</section>
-	);
+            {idx !== navItems.length - 1 && (
+              <Divider spacing="none" thickness="thin" fullBleed={false} />
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/PostNavigation/PostNavigation.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/PostNavigation/PostNavigation.tsx
@@ -7,43 +7,38 @@ import { postNavigationStyles as s } from "./PostNavigation.styles";
 import type { NavItem, PostNavigationProps } from "./PostNavigation.types";
 
 export function PostNavigation({ prevPost, nextPost }: PostNavigationProps) {
-  const navItems: NavItem[] = [
-    prevPost && {
-      label: "이전 작가",
-      artistName: prevPost.title,
-      artistId: String(prevPost.id),
-      direction: "prev",
-    },
-    nextPost && {
-      label: "다음 작가",
-      artistName: nextPost.title,
-      artistId: String(nextPost.id),
-      direction: "next",
-    },
-  ].filter(Boolean) as NavItem[];
+	const navItems: NavItem[] = [
+		prevPost && {
+			label: "이전 작가",
+			artistName: prevPost.title,
+			artistId: String(prevPost.id),
+			direction: "prev",
+		},
+		nextPost && {
+			label: "다음 작가",
+			artistName: nextPost.title,
+			artistId: String(nextPost.id),
+			direction: "next",
+		},
+	].filter(Boolean) as NavItem[];
 
-  if (navItems.length === 0) return null;
+	if (navItems.length === 0) return null;
 
-  return (
-    <section>
-      <Divider
-        spacing="none"
-        thickness="thin"
-        fullBleed={false}
-        color="lighter"
-      />
+	return (
+		<section>
+			<Divider spacing="none" thickness="thin" fullBleed={false} color="lighter" />
 
-      <div className={s.wrapper}>
-        {navItems.map((item, idx) => (
-          <div key={item.artistId}>
-            <Navigator {...item} />
+			<div className={s.wrapper}>
+				{navItems.map((item, idx) => (
+					<div key={item.artistId}>
+						<Navigator {...item} />
 
-            {idx !== navItems.length - 1 && (
-              <Divider spacing="none" thickness="thin" fullBleed={false} />
-            )}
-          </div>
-        ))}
-      </div>
-    </section>
-  );
+						{idx !== navItems.length - 1 && (
+							<Divider spacing="none" thickness="thin" fullBleed={false} />
+						)}
+					</div>
+				))}
+			</div>
+		</section>
+	);
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/page.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/page.tsx
@@ -9,69 +9,69 @@ import { MOCK_ARTIST_DATA } from "@/constants/artist";
 import { MOCK_WORK_DATA } from "@/constants/work";
 import { getPrevNextArtist } from "@/features/artists/mappers/artist.mapper";
 import { transformLinks } from "@/features/artists/mappers/link.mapper";
-import { MOCK_BEHIND_THE_SCENE } from "../../bts/_mocks/behind-the-scene";
 import { Header } from "../../_components/Header";
+import { MOCK_BEHIND_THE_SCENE } from "../../bts/_mocks/behind-the-scene";
 
 interface ArtistDetailPageProps {
-  params: Promise<{ schoolId: string; exhibitionId: string; artistId: string }>;
+	params: Promise<{ schoolId: string; exhibitionId: string; artistId: string }>;
 }
 
 export default async function ArtistDetailPage({ params }: ArtistDetailPageProps) {
-  const { schoolId, exhibitionId, artistId } = await params;
+	const { schoolId, exhibitionId, artistId } = await params;
 
-  const artist = MOCK_ARTIST_DATA.find((a) => a.id === artistId);
-  if (!artist) return <div>작가 없음</div>;
+	const artist = MOCK_ARTIST_DATA.find((a) => a.id === artistId);
+	if (!artist) return <div>작가 없음</div>;
 
-  const { prev, next } = getPrevNextArtist(MOCK_ARTIST_DATA, artistId);
-  const linkItems = transformLinks(artist.email, artist.sns);
-  const btsItems = MOCK_BEHIND_THE_SCENE.filter((b) => b.artistId === artistId);
+	const { prev, next } = getPrevNextArtist(MOCK_ARTIST_DATA, artistId);
+	const linkItems = transformLinks(artist.email, artist.sns);
+	const btsItems = MOCK_BEHIND_THE_SCENE.filter((b) => b.artistId === artistId);
 
-  return (
-    <>
-      <Header variant="back" title="작가 상세" />
-      <div className="flex flex-col px-4 w-full mx-auto">
-        <section>
-          <ProfileCard
-            imageUrl={artist.imageUrl ?? "/images/artists/artist2.png"}
-            name={artist.name}
-            engName={artist.engName}
-            bio={artist.bio}
-          />
-        </section>
+	return (
+		<>
+			<Header variant="back" title="작가 상세" />
+			<div className="flex flex-col px-4 w-full mx-auto">
+				<section>
+					<ProfileCard
+						imageUrl={artist.imageUrl ?? "/images/artists/artist2.png"}
+						name={artist.name}
+						engName={artist.engName}
+						bio={artist.bio}
+					/>
+				</section>
 
-        <Title title="연락처" size="head2" />
-        <LinkCard items={linkItems} />
+				<Title title="연락처" size="head2" />
+				<LinkCard items={linkItems} />
 
-        <Divider />
+				<Divider />
 
-        {/* Behind */}
-        {btsItems.length > 0 && (
-          <section className="mb-8">
-            <Title title="Behind The Scene" size="head2" margin="compact" />
-            <div className="mt-4">
-              <BTSCardGrid
-                items={btsItems}
-                getHref={(item) => `/${schoolId}/exhibition/${exhibitionId}/bts/${item.id}`}
-              />
-            </div>
-          </section>
-        )}
+				{/* Behind */}
+				{btsItems.length > 0 && (
+					<section className="mb-8">
+						<Title title="Behind The Scene" size="head2" margin="compact" />
+						<div className="mt-4">
+							<BTSCardGrid
+								items={btsItems}
+								getHref={(item) => `/${schoolId}/exhibition/${exhibitionId}/bts/${item.id}`}
+							/>
+						</div>
+					</section>
+				)}
 
-        {/* 작품 */}
-        <section className="mb-6">
-          <Title title="작품" size="head2" margin="compact" />
-          <ListCardGrid items={MOCK_WORK_DATA} limit={3} />
-        </section>
+				{/* 작품 */}
+				<section className="mb-6">
+					<Title title="작품" size="head2" margin="compact" />
+					<ListCardGrid items={MOCK_WORK_DATA} limit={3} />
+				</section>
 
-        {/* 작가 둘러보기 */}
-        <section className="mt-7 flex flex-col gap-2.5 mb-6">
-          <Title title="작가 둘러보기" size="body1-bold" color="lighter" margin="none" />
-          <PostNavigation
-            prevPost={prev ? { id: prev.id, title: prev.name } : undefined}
-            nextPost={next ? { id: next.id, title: next.name } : undefined}
-          />
-        </section>
-      </div>
-    </>
-  );
+				{/* 작가 둘러보기 */}
+				<section className="mt-7 flex flex-col gap-2.5 mb-6">
+					<Title title="작가 둘러보기" size="body1-bold" color="lighter" margin="none" />
+					<PostNavigation
+						prevPost={prev ? { id: prev.id, title: prev.name } : undefined}
+						nextPost={next ? { id: next.id, title: next.name } : undefined}
+					/>
+				</section>
+			</div>
+		</>
+	);
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/page.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/page.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { useParams } from "next/navigation";
 import { PostNavigation } from "@/app/[schoolId]/exhibition/[exhibitionId]/artist/[artistId]/components/Navigation/PostNavigation/PostNavigation";
 import { BTSCardGrid } from "@/components/common/Card/BTSCard/BTSCardGrid";
 import { LinkCard } from "@/components/common/Card/LinkCard/LinkCard";
@@ -12,81 +9,69 @@ import { MOCK_ARTIST_DATA } from "@/constants/artist";
 import { MOCK_WORK_DATA } from "@/constants/work";
 import { getPrevNextArtist } from "@/features/artists/mappers/artist.mapper";
 import { transformLinks } from "@/features/artists/mappers/link.mapper";
+import { MOCK_BEHIND_THE_SCENE } from "../../bts/_mocks/behind-the-scene";
 import { Header } from "../../_components/Header";
 
-export default function ArtistDetailPage() {
-	const params = useParams();
+interface ArtistDetailPageProps {
+  params: Promise<{ schoolId: string; exhibitionId: string; artistId: string }>;
+}
 
-	const schoolId = params?.schoolId;
-	const id = params?.artistId;
-	const schoolIdStr = Array.isArray(schoolId) ? schoolId[0] : schoolId || "";
-	const idStr = Array.isArray(id) ? id[0] : id || "";
+export default async function ArtistDetailPage({ params }: ArtistDetailPageProps) {
+  const { schoolId, exhibitionId, artistId } = await params;
 
-	const { prev, next } = getPrevNextArtist(MOCK_ARTIST_DATA, idStr);
+  const artist = MOCK_ARTIST_DATA.find((a) => a.id === artistId);
+  if (!artist) return <div>작가 없음</div>;
 
-	const artist = MOCK_ARTIST_DATA.find((a) => a.id === idStr);
-	if (!artist) return <div>작가 없음</div>;
+  const { prev, next } = getPrevNextArtist(MOCK_ARTIST_DATA, artistId);
+  const linkItems = transformLinks(artist.email, artist.sns);
+  const btsItems = MOCK_BEHIND_THE_SCENE.filter((b) => b.artistId === artistId);
 
-	const linkItems = transformLinks(artist.email, artist.sns);
+  return (
+    <>
+      <Header variant="back" title="작가 상세" />
+      <div className="flex flex-col px-4 w-full mx-auto">
+        <section>
+          <ProfileCard
+            imageUrl={artist.imageUrl ?? "/images/artists/artist2.png"}
+            name={artist.name}
+            engName={artist.engName}
+            bio={artist.bio}
+          />
+        </section>
 
-	return (
-		<>
-			<Header variant="back" title="작가 상세" />
-			<div className="flex flex-col px-4 gap-4 w-full mx-auto">
-				<section>
-					<ProfileCard
-						imageUrl={artist.imageUrl ?? "/images/artists/artist2.png"}
-						name={artist.name}
-						engName={artist.engName}
-						bio={artist.bio}
-					/>
-				</section>
+        <Title title="연락처" size="head2" />
+        <LinkCard items={linkItems} />
 
-				<Title title="연락처" size="head2" />
-				<LinkCard items={linkItems} />
+        <Divider />
 
-				{/* 구분선 */}
-				<Divider />
+        {/* Behind */}
+        {btsItems.length > 0 && (
+          <section className="mb-8">
+            <Title title="Behind The Scene" size="head2" margin="compact" />
+            <div className="mt-4">
+              <BTSCardGrid
+                items={btsItems}
+                getHref={(item) => `/${schoolId}/exhibition/${exhibitionId}/bts/${item.id}`}
+              />
+            </div>
+          </section>
+        )}
 
-				{/* Behind */}
-				<section className="mb-8">
-					<Title title="Behind The Scene" size="head2" />
+        {/* 작품 */}
+        <section className="mb-6">
+          <Title title="작품" size="head2" margin="compact" />
+          <ListCardGrid items={MOCK_WORK_DATA} limit={3} />
+        </section>
 
-					<div className="mt-4">
-						<BTSCardGrid
-							items={[
-								{
-									id: 1,
-									title: "내가 흙을 사랑하는 이유",
-									author: "강슬기",
-									imageUrl: "/images/bts/bts1.png",
-								},
-								{
-									id: 2,
-									title: "내가 흙을 사랑하는 이유",
-									author: "강슬기",
-									imageUrl: "/images/bts/bts1.png",
-								},
-							]}
-						/>
-					</div>
-				</section>
-
-				{/* 작품 */}
-				<section>
-					<Title title="작품" size="head2" />
-					<ListCardGrid items={MOCK_WORK_DATA} limit={3} />
-				</section>
-
-				{/* 작가 둘러보기 */}
-				<section>
-					<Title title="작가 둘러보기" size="body1-bold" color="lighter" />
-					<PostNavigation
-						prevPost={prev ? { id: prev.id, title: prev.name } : undefined}
-						nextPost={next ? { id: next.id, title: next.name } : undefined}
-					/>
-				</section>
-			</div>
-		</>
-	);
+        {/* 작가 둘러보기 */}
+        <section className="mt-7 flex flex-col gap-2.5 mb-6">
+          <Title title="작가 둘러보기" size="body1-bold" color="lighter" margin="none" />
+          <PostNavigation
+            prevPost={prev ? { id: prev.id, title: prev.name } : undefined}
+            nextPost={next ? { id: next.id, title: next.name } : undefined}
+          />
+        </section>
+      </div>
+    </>
+  );
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/_mocks/partners.ts
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/_mocks/partners.ts
@@ -1,0 +1,59 @@
+export interface Member {
+  member_id: string;
+  member_name: string;
+  member_name_en: string | null;
+  member_email: string | null;
+  member_image_url: string | null;
+}
+
+export interface Part {
+  part_id: string;
+  part_name: string;
+  order: number;
+  members: Member[];
+}
+
+export const MOCK_PARTNERS: Part[] = [
+  {
+    part_id: "p1b2c3d4-e29b-41d4-a716-446655440001",
+    part_name: "지도 교수님",
+    order: 1,
+    members: [
+      {
+        member_id: "m1",
+        member_name: "홍길동",
+        member_name_en: null,
+        member_email: "hong@dolog.site",
+        member_image_url: null,
+      },
+      {
+        member_id: "m2",
+        member_name: "김철수",
+        member_name_en: "Kim Cheolsu",
+        member_email: "kim@dolog.site",
+        member_image_url: null,
+      },
+    ],
+  },
+  {
+    part_id: "p1b2c3d4-e29b-41d4-a716-446655440002",
+    part_name: "전시 준비 위원회",
+    order: 2,
+    members: [
+      {
+        member_id: "m3",
+        member_name: "이영희",
+        member_name_en: "Lee Younghee",
+        member_email: "lee@dolog.site",
+        member_image_url: null,
+      },
+      {
+        member_id: "m4",
+        member_name: "박민준",
+        member_name_en: "Park Minjun",
+        member_email: null,
+        member_image_url: null,
+      },
+    ],
+  },
+];

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/_mocks/partners.ts
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/_mocks/partners.ts
@@ -1,59 +1,59 @@
 export interface Member {
-  member_id: string;
-  member_name: string;
-  member_name_en: string | null;
-  member_email: string | null;
-  member_image_url: string | null;
+	member_id: string;
+	member_name: string;
+	member_name_en: string | null;
+	member_email: string | null;
+	member_image_url: string | null;
 }
 
 export interface Part {
-  part_id: string;
-  part_name: string;
-  order: number;
-  members: Member[];
+	part_id: string;
+	part_name: string;
+	order: number;
+	members: Member[];
 }
 
 export const MOCK_PARTNERS: Part[] = [
-  {
-    part_id: "p1b2c3d4-e29b-41d4-a716-446655440001",
-    part_name: "지도 교수님",
-    order: 1,
-    members: [
-      {
-        member_id: "m1",
-        member_name: "홍길동",
-        member_name_en: null,
-        member_email: "hong@dolog.site",
-        member_image_url: null,
-      },
-      {
-        member_id: "m2",
-        member_name: "김철수",
-        member_name_en: "Kim Cheolsu",
-        member_email: "kim@dolog.site",
-        member_image_url: null,
-      },
-    ],
-  },
-  {
-    part_id: "p1b2c3d4-e29b-41d4-a716-446655440002",
-    part_name: "전시 준비 위원회",
-    order: 2,
-    members: [
-      {
-        member_id: "m3",
-        member_name: "이영희",
-        member_name_en: "Lee Younghee",
-        member_email: "lee@dolog.site",
-        member_image_url: null,
-      },
-      {
-        member_id: "m4",
-        member_name: "박민준",
-        member_name_en: "Park Minjun",
-        member_email: null,
-        member_image_url: null,
-      },
-    ],
-  },
+	{
+		part_id: "p1b2c3d4-e29b-41d4-a716-446655440001",
+		part_name: "지도 교수님",
+		order: 1,
+		members: [
+			{
+				member_id: "m1",
+				member_name: "홍길동",
+				member_name_en: null,
+				member_email: "hong@dolog.site",
+				member_image_url: null,
+			},
+			{
+				member_id: "m2",
+				member_name: "김철수",
+				member_name_en: "Kim Cheolsu",
+				member_email: "kim@dolog.site",
+				member_image_url: null,
+			},
+		],
+	},
+	{
+		part_id: "p1b2c3d4-e29b-41d4-a716-446655440002",
+		part_name: "전시 준비 위원회",
+		order: 2,
+		members: [
+			{
+				member_id: "m3",
+				member_name: "이영희",
+				member_name_en: "Lee Younghee",
+				member_email: "lee@dolog.site",
+				member_image_url: null,
+			},
+			{
+				member_id: "m4",
+				member_name: "박민준",
+				member_name_en: "Park Minjun",
+				member_email: null,
+				member_image_url: null,
+			},
+		],
+	},
 ];

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/page.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/page.tsx
@@ -7,54 +7,52 @@ import { Header } from "../_components/Header";
 import { MOCK_PARTNERS } from "./_mocks/partners";
 
 interface ArtistPageProps {
-  params: Promise<{ schoolId: string; exhibitionId: string }>;
+	params: Promise<{ schoolId: string; exhibitionId: string }>;
 }
 
 export default async function ArtistPage({ params }: ArtistPageProps) {
-  const { schoolId, exhibitionId } = await params;
+	const { schoolId, exhibitionId } = await params;
 
-  return (
-    <>
-      <Header variant="logo" />
-      <div className="flex flex-col w-full px-4">
-        <Title title="참여한 사람들" />
+	return (
+		<>
+			<Header variant="logo" />
+			<div className="flex flex-col w-full px-4">
+				<Title title="참여한 사람들" />
 
-        {/* 작가 리스트 */}
-        <section className="flex flex-col pb-6">
-          <Title title="작가" size="head2" />
-          <CardGrid
-            items={MOCK_ARTIST_DATA.map((artist) => ({
-              id: artist.id,
-              title: artist.name ?? "이름",
-              author: artist.engName ?? "Name",
-              imageUrl: artist.imageUrl,
-              category: "",
-            }))}
-            getHref={(item) =>
-              `/${schoolId}/exhibition/${exhibitionId}/artist/${item.id}`
-            }
-          />
-        </section>
+				{/* 작가 리스트 */}
+				<section className="flex flex-col pb-6">
+					<Title title="작가" size="head2" />
+					<CardGrid
+						items={MOCK_ARTIST_DATA.map((artist) => ({
+							id: artist.id,
+							title: artist.name ?? "이름",
+							author: artist.engName ?? "Name",
+							imageUrl: artist.imageUrl,
+							category: "",
+						}))}
+						getHref={(item) => `/${schoolId}/exhibition/${exhibitionId}/artist/${item.id}`}
+					/>
+				</section>
 
-        <Divider />
+				<Divider />
 
-        {/* 도움을 주신 분들 */}
-        <Title title="도움을 주신 분들" />
-        {MOCK_PARTNERS.sort((a, b) => a.order - b.order).map((part) => (
-          <section key={part.part_id} className="flex flex-col mb-6">
-            <Title title={part.part_name} size="head2" margin="compact" />
-            <RowCardGrid
-              items={part.members.map((m) => ({
-                id: m.member_id,
-                name: m.member_name,
-                engName: m.member_name_en ?? undefined,
-                email: m.member_email ?? undefined,
-                imageUrl: m.member_image_url ?? undefined,
-              }))}
-            />
-          </section>
-        ))}
-      </div>
-    </>
-  );
+				{/* 도움을 주신 분들 */}
+				<Title title="도움을 주신 분들" />
+				{MOCK_PARTNERS.sort((a, b) => a.order - b.order).map((part) => (
+					<section key={part.part_id} className="flex flex-col mb-6">
+						<Title title={part.part_name} size="head2" margin="compact" />
+						<RowCardGrid
+							items={part.members.map((m) => ({
+								id: m.member_id,
+								name: m.member_name,
+								engName: m.member_name_en ?? undefined,
+								email: m.member_email ?? undefined,
+								imageUrl: m.member_image_url ?? undefined,
+							}))}
+						/>
+					</section>
+				))}
+			</div>
+		</>
+	);
 }

--- a/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/page.tsx
+++ b/apps/client/app/[schoolId]/exhibition/[exhibitionId]/artist/page.tsx
@@ -1,60 +1,60 @@
-"use client";
-
-import { useParams } from "next/navigation";
 import { CardGrid } from "@/components/common/Card/CardGrid";
 import { RowCardGrid } from "@/components/common/Card/RowCard/RowCardGrid";
 import { Divider } from "@/components/common/Divider/Divider";
 import { Title } from "@/components/common/Title/Title";
 import { MOCK_ARTIST_DATA } from "@/constants/artist";
 import { Header } from "../_components/Header";
+import { MOCK_PARTNERS } from "./_mocks/partners";
 
-export default function ArtistDetailPage() {
-	const params = useParams();
-	const schoolId = params?.schoolId;
-	const id = params?.id;
+interface ArtistPageProps {
+  params: Promise<{ schoolId: string; exhibitionId: string }>;
+}
 
-	const schoolIdStr = Array.isArray(schoolId) ? schoolId[0] : schoolId || "";
-	const exhibitionId = params?.exhibitionId;
-	const exhibitionIdStr = Array.isArray(exhibitionId) ? exhibitionId[0] : exhibitionId || "";
+export default async function ArtistPage({ params }: ArtistPageProps) {
+  const { schoolId, exhibitionId } = await params;
 
-	return (
-		<>
-			<Header variant="logo" />
-			{/* 페이지 타이틀 */}
-			<div className="flex flex-col w-full px-4">
-				<Title title="참여한 사람들" />
+  return (
+    <>
+      <Header variant="logo" />
+      <div className="flex flex-col w-full px-4">
+        <Title title="참여한 사람들" />
 
-				{/* 작가 리스트 */}
-				<section className="flex flex-col">
-					<Title title="작가" size="head2" />
-					<CardGrid
-						items={MOCK_ARTIST_DATA.map((artist) => ({
-							id: artist.id,
-							title: artist.name ?? "이름",
-							author: artist.engName ?? "Name",
-							imageUrl: artist.imageUrl,
-							category: "",
-						}))}
-						getHref={(item) => `/${schoolIdStr}/exhibition/${exhibitionIdStr}/artist/${item.id}`}
-					/>
-				</section>
+        {/* 작가 리스트 */}
+        <section className="flex flex-col pb-6">
+          <Title title="작가" size="head2" />
+          <CardGrid
+            items={MOCK_ARTIST_DATA.map((artist) => ({
+              id: artist.id,
+              title: artist.name ?? "이름",
+              author: artist.engName ?? "Name",
+              imageUrl: artist.imageUrl,
+              category: "",
+            }))}
+            getHref={(item) =>
+              `/${schoolId}/exhibition/${exhibitionId}/artist/${item.id}`
+            }
+          />
+        </section>
 
-				{/* 구분선 */}
-				<Divider />
+        <Divider />
 
-				{/* 도움을 주신 분들 */}
-				<Title title="도움을 주신 분들" />
-				<section className="flex flex-col mb-6">
-					<Title title="지도 교수님" size="head2" />
-					<RowCardGrid items={MOCK_ARTIST_DATA} />
-				</section>
-
-				{/* 전시 준비 위원회 */}
-				<section className="flex flex-col">
-					<Title title="전시 준비 위원회" size="head2" />
-					<RowCardGrid items={MOCK_ARTIST_DATA} />
-				</section>
-			</div>
-		</>
-	);
+        {/* 도움을 주신 분들 */}
+        <Title title="도움을 주신 분들" />
+        {MOCK_PARTNERS.sort((a, b) => a.order - b.order).map((part) => (
+          <section key={part.part_id} className="flex flex-col mb-6">
+            <Title title={part.part_name} size="head2" margin="compact" />
+            <RowCardGrid
+              items={part.members.map((m) => ({
+                id: m.member_id,
+                name: m.member_name,
+                engName: m.member_name_en ?? undefined,
+                email: m.member_email ?? undefined,
+                imageUrl: m.member_image_url ?? undefined,
+              }))}
+            />
+          </section>
+        ))}
+      </div>
+    </>
+  );
 }

--- a/apps/client/components/common/Card/BTSCard/BTSCard.tsx
+++ b/apps/client/components/common/Card/BTSCard/BTSCard.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Image from "next/image";
 import { btsCardStyles as s } from "./BTSCard.styles";
 

--- a/apps/client/components/common/Card/BTSCard/BTSCardGrid.tsx
+++ b/apps/client/components/common/Card/BTSCard/BTSCardGrid.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Link from "next/link";
 import { BTSCard } from "./BTSCard";
 

--- a/apps/client/components/common/Card/ProfileCard/ProfileCard.styles.ts
+++ b/apps/client/components/common/Card/ProfileCard/ProfileCard.styles.ts
@@ -1,16 +1,16 @@
 export const profileCardStyles = {
-  wrapper: "flex flex-col w-full",
+	wrapper: "flex flex-col w-full",
 
-  top: "flex gap-[12px] mt-4 mb-4",
+	top: "flex gap-[12px] mt-4 mb-4",
 
-  image: "w-[150px] h-[200px] object-cover",
+	image: "w-[150px] h-[200px] object-cover",
 
-  textWrapper: "flex flex-col flex-1",
+	textWrapper: "flex flex-col flex-1",
 
-  textInner: "flex flex-col mt-auto",
+	textInner: "flex flex-col mt-auto",
 
-  name: "text-head3 text-strong",
-  engName: "text-body2 text-light mt-[4px]",
+	name: "text-head3 text-strong",
+	engName: "text-body2 text-light mt-[4px]",
 
-  bio: "text-body1 text-light leading-[24px]",
+	bio: "text-body1 text-light leading-[24px]",
 };

--- a/apps/client/components/common/Card/ProfileCard/ProfileCard.styles.ts
+++ b/apps/client/components/common/Card/ProfileCard/ProfileCard.styles.ts
@@ -1,16 +1,16 @@
 export const profileCardStyles = {
-	wrapper: "flex flex-col gap-4 w-full pt-4",
+  wrapper: "flex flex-col w-full",
 
-	top: "flex gap-[12px]",
+  top: "flex gap-[12px] mt-4 mb-4",
 
-	image: "w-[150px] h-[200px] object-cover",
+  image: "w-[150px] h-[200px] object-cover",
 
-	textWrapper: "flex flex-col flex-1",
+  textWrapper: "flex flex-col flex-1",
 
-	textInner: "flex flex-col mt-auto",
+  textInner: "flex flex-col mt-auto",
 
-	name: "text-head3",
-	engName: "text-body2 text-light mt-[4px]",
+  name: "text-head3 text-strong",
+  engName: "text-body2 text-light mt-[4px]",
 
-	bio: "text-body1 text-light leading-[24px] mt-2",
+  bio: "text-body1 text-light leading-[24px]",
 };

--- a/apps/client/components/common/Card/RowCard/RowCard.styles.ts
+++ b/apps/client/components/common/Card/RowCard/RowCard.styles.ts
@@ -1,14 +1,14 @@
 export const rowCardStyles = {
-  wrapper: "flex gap-[12px] items-center w-full",
+	wrapper: "flex gap-[12px] items-center w-full",
 
-  imageWrapper: "w-[72px] h-[96px] overflow-hidden flex-shrink-0",
-  image: "w-[72px] h-[96px] object-cover",
+	imageWrapper: "w-[72px] h-[96px] overflow-hidden flex-shrink-0",
+	image: "w-[72px] h-[96px] object-cover",
 
-  info: "flex-1 flex flex-col gap-[4px]",
+	info: "flex-1 flex flex-col gap-[4px]",
 
-  nameRow: "flex items-center gap-[10px]",
+	nameRow: "flex items-center gap-[10px]",
 
-  nameKr: "text-body1-bold text-strong",
-  nameEn: "text-body1 text-light",
-  email: "text-body2 text-light",
+	nameKr: "text-body1-bold text-strong",
+	nameEn: "text-body1 text-light",
+	email: "text-body2 text-light",
 };

--- a/apps/client/components/common/Card/RowCard/RowCard.styles.ts
+++ b/apps/client/components/common/Card/RowCard/RowCard.styles.ts
@@ -1,14 +1,14 @@
 export const rowCardStyles = {
-	wrapper: "flex gap-[12px] items-center w-full",
+  wrapper: "flex gap-[12px] items-center w-full",
 
-	imageWrapper: "w-[72px] h-[96px] overflow-hidden rounded-md flex-shrink-0",
-	image: "w-[72px] h-[96px] object-cover",
+  imageWrapper: "w-[72px] h-[96px] overflow-hidden flex-shrink-0",
+  image: "w-[72px] h-[96px] object-cover",
 
-	info: "flex-1 flex flex-col gap-[4px]",
+  info: "flex-1 flex flex-col gap-[4px]",
 
-	nameRow: "flex items-center gap-[8px]",
+  nameRow: "flex items-center gap-[10px]",
 
-	nameKr: "text-body1-bold text-medium",
-	nameEn: "text-body1 text-light",
-	email: "text-body2 text-regular",
+  nameKr: "text-body1-bold text-strong",
+  nameEn: "text-body1 text-light",
+  email: "text-body2 text-light",
 };

--- a/apps/client/components/common/Footer/SchoolFooter.tsx
+++ b/apps/client/components/common/Footer/SchoolFooter.tsx
@@ -1,50 +1,45 @@
 import Image from "next/image";
 
 interface SchoolFooterProps {
-  logoSrc?: string;
-  title: string;
-  department: string;
-  address: string;
-  addressDetail: string;
-  email: string;
-  copyright: string;
+	logoSrc?: string;
+	title: string;
+	department: string;
+	address: string;
+	addressDetail: string;
+	email: string;
+	copyright: string;
 }
 
 export default function SchoolFooter({
-  logoSrc,
-  title,
-  department,
-  address,
-  addressDetail,
-  email,
-  copyright,
+	logoSrc,
+	title,
+	department,
+	address,
+	addressDetail,
+	email,
+	copyright,
 }: SchoolFooterProps) {
-  return (
-    <footer className="w-full pb-8 flex flex-col mt-12 bg-fg-lighter">
-      <div className="flex pt-6 flex-col px-4">
-        <div className="flex flex-col gap-1">
-          <h3 className="text-body1-bold text-light">{title}</h3>
-          <div className="h-5 w-full" />
-          <p className="text-body2 text-lighter">{department}</p>
-          <div>
-            <p className="text-body2 text-lighter">{address}</p>
-            <p className="text-body2 text-lighter">{addressDetail}</p>
-          </div>
-          <p className="text-body2 text-lighter">{email}</p>
-        </div>
-        <div className="h-3 w-full" />
-        <p className="text-lightest text-body3-bold">
-          {copyright} <br />
-          All Rights reserved.
-        </p>
-        <div className="h-7 w-full" />
-        <Image
-          src={logoSrc || "/images/logo.svg"}
-          alt={`${title} Logo`}
-          width={60}
-          height={18}
-        />
-      </div>
-    </footer>
-  );
+	return (
+		<footer className="w-full pb-8 flex flex-col mt-12 bg-fg-lighter">
+			<div className="flex pt-6 flex-col px-4">
+				<div className="flex flex-col gap-1">
+					<h3 className="text-body1-bold text-light">{title}</h3>
+					<div className="h-5 w-full" />
+					<p className="text-body2 text-lighter">{department}</p>
+					<div>
+						<p className="text-body2 text-lighter">{address}</p>
+						<p className="text-body2 text-lighter">{addressDetail}</p>
+					</div>
+					<p className="text-body2 text-lighter">{email}</p>
+				</div>
+				<div className="h-3 w-full" />
+				<p className="text-lightest text-body3-bold">
+					{copyright} <br />
+					All Rights reserved.
+				</p>
+				<div className="h-7 w-full" />
+				<Image src={logoSrc || "/images/logo.svg"} alt={`${title} Logo`} width={60} height={18} />
+			</div>
+		</footer>
+	);
 }

--- a/apps/client/components/common/Footer/SchoolFooter.tsx
+++ b/apps/client/components/common/Footer/SchoolFooter.tsx
@@ -1,45 +1,50 @@
 import Image from "next/image";
 
 interface SchoolFooterProps {
-	logoSrc?: string;
-	title: string;
-	department: string;
-	address: string;
-	addressDetail: string;
-	email: string;
-	copyright: string;
+  logoSrc?: string;
+  title: string;
+  department: string;
+  address: string;
+  addressDetail: string;
+  email: string;
+  copyright: string;
 }
 
 export default function SchoolFooter({
-	logoSrc,
-	title,
-	department,
-	address,
-	addressDetail,
-	email,
-	copyright,
+  logoSrc,
+  title,
+  department,
+  address,
+  addressDetail,
+  email,
+  copyright,
 }: SchoolFooterProps) {
-	return (
-		<footer className="w-full pt-6 pb-8 flex flex-col mt-12 bg-fg-lighter">
-			<div className="flex flex-col px-4">
-				<div className="flex flex-col gap-1">
-					<h3 className="text-body1-bold text-light">{title}</h3>
-					<div className="h-5 w-full" />
-					<p className="text-body2 text-lighter">{department}</p>
-					<div>
-						<p className="text-body2 text-lighter">{address}</p>
-						<p className="text-body2 text-lighter">{addressDetail}</p>
-					</div>
-					<p className="text-body2 text-lighter">{email}</p>
-				</div>
-				<div className="h-3 w-full" />
-				<p className="text-lightest text-body3-bold">
-					{copyright} <br />
-					All Rights reserved.
-				</p>
-				<div className="h-7 w-full" />
-				<Image src={logoSrc || "/images/logo.svg"} alt={`${title} Logo`} width={60} height={18} />
-			</div>
-		</footer>
-	);
+  return (
+    <footer className="w-full pb-8 flex flex-col mt-12 bg-fg-lighter">
+      <div className="flex pt-6 flex-col px-4">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-body1-bold text-light">{title}</h3>
+          <div className="h-5 w-full" />
+          <p className="text-body2 text-lighter">{department}</p>
+          <div>
+            <p className="text-body2 text-lighter">{address}</p>
+            <p className="text-body2 text-lighter">{addressDetail}</p>
+          </div>
+          <p className="text-body2 text-lighter">{email}</p>
+        </div>
+        <div className="h-3 w-full" />
+        <p className="text-lightest text-body3-bold">
+          {copyright} <br />
+          All Rights reserved.
+        </p>
+        <div className="h-7 w-full" />
+        <Image
+          src={logoSrc || "/images/logo.svg"}
+          alt={`${title} Logo`}
+          width={60}
+          height={18}
+        />
+      </div>
+    </footer>
+  );
 }


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

- 참여한 사람들 페이지: 도움을 주신 분들 섹션 하드코딩 제거 → mock 데이터 기반 동적 렌더링
- 작가 상세 페이지: BTS 하드코딩 제거 → mock 데이터에서 artistId로 필터링, BTS 상세 페이지 이동 연결                                                  
- BTS가 없는 작가의 경우 Behind The Scene 섹션 미노출 처리
- `use client` + `useParams` 제거 → 서버 컴포넌트로 전환

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

- `MOCK_PARTNERS`는 백엔드 API 스펙(`/exhibitions/{id}/partners`)에 맞춰 구성했습니다.   
- `member_name_en` 필드는 현재 API 스펙에 없어 백엔드에 추가 요청 예정입니다.                                                                
- API 연동 시 mock 데이터 → fetch 결과로 교체만 하면 됩니다.


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`ArtistPage`

-`MOCK_PARTNERS`의 `parts` 배열을 `order` 순으로 정렬해 섹션을 동적으로 렌더링합니다.

```typescript
  {MOCK_PARTNERS.sort((a, b) => a.order - b.order).map((part) => (
    <section key={part.part_id} className="flex flex-col mb-6">
      <Title title={part.part_name} size="head2" margin="compact" />         
      <RowCardGrid items={part.members.map((m) => ({ ... }))} />
    </section>                                                               
  ))}
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- closed #46
