### PR TITLE
feat: 페이지별 OG 메타데이터 추가

### DIFF
--- a/apps/client/app/[exhibitionId]/artist/[artistId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/artist/[artistId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { PostNavigation } from "@/app/[exhibitionId]/artist/[artistId]/components/Navigation/PostNavigation/PostNavigation";
 import { BTSCardGrid } from "@/components/common/Card/BTSCard/BTSCardGrid";
 import { LinkCard } from "@/components/common/Card/LinkCard/LinkCard";
@@ -14,6 +15,19 @@ import { MOCK_BEHIND_THE_SCENE } from "../../bts/_mocks/behind-the-scene";
 
 interface ArtistDetailPageProps {
 	params: Promise<{ exhibitionId: string; artistId: string }>;
+}
+
+export async function generateMetadata({ params }: ArtistDetailPageProps): Promise<Metadata> {
+	const { artistId } = await params;
+	const artist = MOCK_ARTIST_DATA.find((a) => a.id === artistId);
+
+	return {
+		title: artist?.name ?? "작가 소개",
+		openGraph: {
+			title: artist?.name ?? "작가 소개",
+			images: artist?.imageUrl ? [{ url: artist.imageUrl }] : [],
+		},
+	};
 }
 
 export default async function ArtistDetailPage({ params }: ArtistDetailPageProps) {

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/page.tsx
@@ -1,8 +1,20 @@
+import type { Metadata } from "next";
 import { MOCK_ARTWORK_DETAIL } from "@/app/[exhibitionId]/artwork/_mocks/artworkDetail";
 import { ArtworkDetailClient } from "./_components/ArtworkDetailClient";
 
 interface ArtworkDetailPageProps {
 	params: Promise<{ exhibitionId: string }>;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+	const data = MOCK_ARTWORK_DETAIL;
+	return {
+		title: data.title,
+		openGraph: {
+			title: data.title,
+			images: [{ url: data.image }],
+		},
+	};
 }
 
 export default async function ArtworkDetailPage({ params }: ArtworkDetailPageProps) {

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -1,5 +1,16 @@
 import "./globals.css";
+import type { Metadata } from "next";
 import Script from "next/script";
+
+export const metadata: Metadata = {
+	title: "두록",
+	description: "졸업전시 아카이빙 플랫폼 두록",
+	openGraph: {
+		title: "두록",
+		description: "졸업전시 아카이빙 플랫폼 두록",
+		images: [{ url: "/images/og-default.png" }],
+	},
+};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
- 루트 layout에 두록 기본 OG 메타데이터 추가
- 작품 상세 페이지 OG 이미지 → 작품 대표 이미지
- 작가 상세 페이지 OG 이미지 → 작가 프로필 사진

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
- /images/og-default.png` 파일이 public에 있어야 합니다. 디자인팀에서 두록 기본 이미지 받으면 해당 경로에 넣겠습니다.
- 현재는 목데이터 기준으로 구현되어 있으며, 백엔드 연동 시 실제 API 데이터로 교체 예정입니다.

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`OG 메타데이터`

- 각 페이지에서 `generateMetadata`로 동적 OG 태그 설정

```typescript
  export async function generateMetadata({ params }): Promise<Metadata> {
    const artist = MOCK_ARTIST_DATA.find((a) => a.id === artistId);
    return {
      title: artist?.name ?? "작가 소개",
      openGraph: {
        title: artist?.name ?? "작가 소개",
        images: artist?.imageUrl ? [{ url: artist.imageUrl }] : [],
      },
    };
  }
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #43
