### PR TITLE
feat: 작품 상세 페이지 유튜브 임베딩

### DIFF
--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
@@ -11,6 +11,7 @@ import { BtsSection } from "../_components/BtsSection";
 import { DescriptionSection } from "../_components/DescriptionSection";
 import { InfoSection } from "../_components/InfoSection";
 import { LocationSection } from "../_components/LocationSection";
+import { YoutubeSection } from "../_components/YoutubeSection";
 import { PhotoSection } from "../_components/PhotoSection";
 import { PostNavigationSection } from "../_components/PostNavigationSection";
 import { RelatedSection } from "../_components/RelatedSection";
@@ -53,6 +54,8 @@ export function ArtworkDetailClient({
 			>
 				<DescriptionSection content={data.description} />
 			</section>
+			{/*  유튜브 섹션  */}
+			<YoutubeSection youtubeUrl={data.youtubeUrl} />
 			{/* 상세 이미지 섹션*/}
 			<PhotoSection images={data.detailImages} purchaseUrl={data.purchaseUrl} />
 			{/* 참여자 섹션 */}

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/YoutubeSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/YoutubeSection.tsx
@@ -1,0 +1,36 @@
+interface YoutubeSectionProps {
+	youtubeUrl: string | null | undefined;
+}
+
+export function YoutubeSection({ youtubeUrl }: YoutubeSectionProps) {
+	if (!youtubeUrl || youtubeUrl.trim() === "" || youtubeUrl === "null") {
+		return null;
+	}
+
+	// 유튜브 URL에서 비디오 ID 추출 및 임베드 URL 변환
+	const getEmbedUrl = (url: string) => {
+		try {
+			const videoId = url.split("v=")[1]?.split("&")[0] || url.split("/").pop();
+			return `https://www.youtube.com/embed/${videoId}`;
+		} catch (e) {
+			return null;
+		}
+	};
+
+	const embedUrl = getEmbedUrl(youtubeUrl);
+	if (!embedUrl) return null;
+
+	return (
+		<section className="flex flex-col px-4 pb-1 bg-white">
+			<div className="relative w-full aspect-video overflow-hidden shadow-sm">
+				<iframe
+					src={embedUrl}
+					title="YouTube video player"
+					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+					allowFullScreen
+					className="absolute top-0 left-0 w-full h-full border-0"
+				/>
+			</div>
+		</section>
+	);
+}

--- a/apps/client/app/[exhibitionId]/artwork/_mocks/artworkDetail.ts
+++ b/apps/client/app/[exhibitionId]/artwork/_mocks/artworkDetail.ts
@@ -10,6 +10,7 @@ export const MOCK_ARTWORK_DETAIL = {
 		"가장자리의 얇은 물결 라인은 바람이 스치는 수면을 떠올리게 한다. 멀리서 보면 단정한 그릇이지만, 가까이 다가가면 빛에 따라 표면의 요철이 천천히 드러나며 '잔잔한 움직임'을 만든다.\n\n형태는 과하게 흔들리지 않도록 중심을 낮게 잡고, 가장자리만 미세하게 리듬을 주어 쓰임과 조형 사이의 균형을 맞췄다. 유약은 빛을 받는 각도에 따라 색의 깊이가 달라지도록 여러 번 테스트하며 조정했고, 그 결과 같은 그릇이라도 시간과 조명에 따라 다른 표정을 보여준다.\n\n일상에서 자주 마주치는 물의 감각을, 조용하지만 오래 남는 장면으로 담아낸 작품이다.",
 	locationImageUrl: "/images/artwork/artworkLocation.png",
 	detailImages: ["/images/cups.png", "/images/plate.png"],
+	youtubeUrl: "https://www.youtube.com/watch?v=EqVtuTEoErY",
 	purchaseUrl: "https://naver.com",
 	authors: [
 		{


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

- **유튜브 임베딩 섹션 (`YoutubeSection`) 신규 개발**
  - `youtubeUrl` 데이터 존재 여부에 따른 조건부 렌더링 적용 (null, 빈 문자열 시 숨김 처리)
  - 다양한 유튜브 URL 형식(일반, 단축 주소 등) 대응을 위한 정규표현식 기반 ID 추출 로직 구현
  - iframe을 활용한 반응형 16:9 비디오 레이아웃 마크업
  - 상세 페이지 레이아웃 내 유튜브 섹션 적정 위치 배치

## 💡 참고 사항
- 유튜브 URL에서 비디오 ID를 추출한 뒤 `https://www.youtube.com/embed/{ID}` 형태로 변환하여 iframe 보안 정책(X-Frame-Options) 이슈를 해결했습니다.
- 데이터가 비어있을 경우(`""` 혹은 `null`) `YoutubeSection` 컴포넌트가 `null`을 반환하여 레이아웃에서 완전히 제거됩니다.

## 📸 스크린샷

| 구현 내용 |             ---             |       
| :-------: | :-------------------------: | 
|    유튜브임베딩    | 
<img width="200"  alt="image" src="https://github.com/user-attachments/assets/54140aa5-c9b7-47cc-acaa-04c7ed91d71e" />  | 

## 🖥️ 주요 코드 설명

`YoutubeSection - URL 변환 로직`

- 사용자가 입력한 다양한 형태의 유튜브 주소에서 고유 비디오 ID 11자리를 추출합니다.
```typescript
const getEmbedUrl = (url: string) => {
  const regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
  const match = url.match(regExp);
  const videoId = (match && match[7].length === 11) ? match[7] : null;
  return videoId ? `[https://www.youtube.com/embed/$](https://www.youtube.com/embed/$){videoId}` : null;
};
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- Close #59 
