### PR TITLE
feat: 공유 API 클라이언트 인스턴스 추가 및 baseURL 파라미터 제거

### DIFF
--- a/apps/client/app/(main)/exhibitions/page.tsx
+++ b/apps/client/app/(main)/exhibitions/page.tsx
@@ -3,8 +3,8 @@ import { MOCK_EXHIBITIONS } from "../_mocks/exhibition";
 import ExhibitionsClient from "./_components/ExhibitionsClient";
 
 export default async function ExhibitionsPage() {
-	const baseURL = process.env.NEXT_PUBLIC_API_URL;
-	const exhibitions = baseURL ? await getExhibitions(baseURL) : MOCK_EXHIBITIONS;
+	const exhibitions = await getExhibitions();
+	const displayExhibitions = exhibitions.length > 0 ? exhibitions : MOCK_EXHIBITIONS;
 
-	return <ExhibitionsClient exhibitions={exhibitions} />;
+	return <ExhibitionsClient exhibitions={displayExhibitions} />;
 }

--- a/apps/client/app/[exhibitionId]/_api/resolveExhibitionId.ts
+++ b/apps/client/app/[exhibitionId]/_api/resolveExhibitionId.ts
@@ -5,8 +5,6 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 export const resolveExhibitionId = cache(async (exhibitionId: string): Promise<string | null> => {
 	if (UUID_REGEX.test(exhibitionId)) return exhibitionId;
-	const baseURL = process.env.NEXT_PUBLIC_API_URL;
-	if (!baseURL) return null;
-	const result = await resolveExhibitionSlug(baseURL, exhibitionId);
+	const result = await resolveExhibitionSlug(exhibitionId);
 	return result?.uuid ?? null;
 });

--- a/apps/client/lib/api/exhibition.ts
+++ b/apps/client/lib/api/exhibition.ts
@@ -1,4 +1,4 @@
-import { createApiClient } from "api";
+import { apiClient } from "api";
 
 export interface ExhibitionListItem {
 	id: string;
@@ -12,22 +12,17 @@ export interface ExhibitionListItem {
 	dDay: number | null;
 }
 
-export async function getExhibitions(baseURL: string): Promise<ExhibitionListItem[]> {
-	const fetcher = createApiClient(baseURL);
+export async function getExhibitions(): Promise<ExhibitionListItem[]> {
 	try {
-		return await fetcher<ExhibitionListItem[]>("/exhibitions");
+		return await apiClient<ExhibitionListItem[]>("/exhibitions");
 	} catch {
 		return [];
 	}
 }
 
-export async function resolveExhibitionSlug(
-	baseURL: string,
-	slug: string,
-): Promise<{ uuid: string } | null> {
-	const fetcher = createApiClient(baseURL);
+export async function resolveExhibitionSlug(slug: string): Promise<{ uuid: string } | null> {
 	try {
-		return await fetcher<{ uuid: string }>(`/exhibitions/resolve/${slug}`);
+		return await apiClient<{ uuid: string }>(`/exhibitions/resolve/${slug}`);
 	} catch {
 		return null;
 	}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "packageManager": "pnpm@10.30.3",
   "devDependencies": {
     "@biomejs/biome": "2.4.8",
+    "@types/node": "^20.19.37",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "lefthook": "^2.1.4"

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1,1 +1,1 @@
-export { createApiClient, apiClient } from "./src/instance";
+export { apiClient, createApiClient } from "./src/instance";

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1,1 +1,1 @@
-export { createApiClient } from "./src/instance";
+export { createApiClient, apiClient } from "./src/instance";

--- a/packages/api/src/instance.ts
+++ b/packages/api/src/instance.ts
@@ -29,3 +29,5 @@ export function createApiClient(baseURL: string) {
 		return json.data;
 	};
 }
+
+export const apiClient = createApiClient(process.env.NEXT_PUBLIC_API_URL ?? "");

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "ES2017",
+		"lib": ["dom", "esnext"],
+		"types": ["node"],
+		"strict": true,
+		"moduleResolution": "bundler",
+		"esModuleInterop": true,
+		"skipLibCheck": true
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.8
         version: 2.4.8
+      '@types/node':
+        specifier: ^20.19.37
+        version: 20.19.37
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -54,7 +57,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.1
@@ -67,15 +70,15 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      api:
+        specifier: workspace:*
+        version: link:../../packages/api
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      api:
-        specifier: workspace:*
-        version: link:../../packages/api
       components:
         specifier: workspace:*
         version: link:../../packages/components
@@ -115,7 +118,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.1


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

packages/api에 공유 API 클라이언트 인스턴스를 추가하고, 기존 API 함수의 baseURL 파라미터를 제거했습니다.

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

- 기존에는 API 함수마다 baseURL을 파라미터로 받아 createApiClient(baseURL)를 호출했는데, 이제 packages/api에서 apiClient를 직접 export해 사용합니다.
- NEXT_PUBLIC_API_URL 환경변수가 없을 경우 빈 문자열로 fallback → fetch 실패 → [] 또는 null 반환 → 목데이터로 처리됩니다.                                                     
- packages/api에 tsconfig.json을 추가해 process 타입 에러를 해결했습니다.


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`apps/client/lib/api/exhibition.ts`

```typescript
  // 전                                                                                        
  export async function getExhibitions(baseURL: string) {                                      
      const fetcher = createApiClient(baseURL);
      return fetcher<ExhibitionListItem[]>("/exhibitions");                                    
  }                                                                                            
  
  // 후                                                                                        
  export async function getExhibitions() {                  
      return apiClient<ExhibitionListItem[]>("/exhibitions");                                  
  }
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #57
