### PR TITLE
fix: 작가 상세 이동 주소 수정, btn hover effect 수정

### DIFF
--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtistSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtistSection.tsx
@@ -14,11 +14,11 @@ export function ArtistSection({ authors }: ArtistSectionProps) {
 		<section className="flex flex-col px-4 pb-6 gap-4">
 			<Title title="참여자" />
 			<div className="flex flex-col gap-10">
-				{authors.map((author, index) => (
+				{authors.map((author) => (
 					<ArtistCard
-						key={index}
+						key={author.profileId}
 						author={author}
-						profileHref={`/${slug}/artist/${author.artistId}`}
+						profileHref={`/${slug}/artist/${author.profileId}`}
 					/>
 				))}
 			</div>

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -122,6 +122,7 @@
     height: 100%;
     margin: 0;
     padding: 0;
+    overflow-x: hidden;
   }
 }
 

--- a/packages/components/src/ui/Button/Button.styles.ts
+++ b/packages/components/src/ui/Button/Button.styles.ts
@@ -11,7 +11,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 export const buttonVariants = cva(
 	// 공통 기본 스타일
-	"inline-flex items-center justify-center hover:scale-101 cursor-pointer",
+	"inline-flex items-center justify-center cursor-pointer",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
- 좌우 화면 흔들리지 않도록 `overflow-x: hidden;` 코드 추가
- 프로필 더보기 클릭시 작가 상세로 이동하도록 수정
- btn hover시 확대 effect 제거

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #74
