### PR TITLE
feat: 전시 UX 개선 - 메타데이터, 필터, SNS 링크, 유형 표시 

### DIFF
--- a/apps/client/app/(main)/_components/Banner.tsx
+++ b/apps/client/app/(main)/_components/Banner.tsx
@@ -68,6 +68,8 @@ export default function Banner({ banners }: { banners: BannerItem[] }) {
 							key={banner.id}
 							href={banner.linkUrl}
 							className="relative min-w-full h-full block"
+							target="_blank"
+							rel="noopener noreferrer"
 						>
 							{banner.imageUrl && (
 								<Image

--- a/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
+++ b/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
@@ -10,27 +10,23 @@ import MainFooter from "@/components/common/Footer/MainFooter";
 
 interface ArtworksClientProps {
 	artworks: CardItem[];
-	exhibitions: string[];
-	categories: string[];
 	slugMap?: Record<string, string>;
 }
 
-export default function ArtworksClient({
-	artworks,
-	exhibitions,
-	categories,
-	slugMap,
-}: ArtworksClientProps) {
+export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProps) {
 	const [searchQuery, setSearchQuery] = useState("");
-	const [selectedExhibition, setSelectedExhibition] = useState<string | null>(null);
-	const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+	const [selectedUniv, setSelectedUniv] = useState<string | null>(null);
+	const [selectedDept, setSelectedDept] = useState<string | null>(null);
+
+	const univs = [...new Set(artworks.map((a) => a.univName).filter(Boolean))] as string[];
+	const depts = [...new Set(artworks.map((a) => a.deptName).filter(Boolean))] as string[];
 
 	const filtered = artworks.filter((item) => {
-		const matchExhibition = !selectedExhibition || item.exhibitionTitle === selectedExhibition;
-		const matchCategory = !selectedCategory || item.category === selectedCategory;
+		const matchUniv = !selectedUniv || item.univName === selectedUniv;
+		const matchDept = !selectedDept || item.deptName === selectedDept;
 		const matchSearch =
 			!searchQuery || item.title.includes(searchQuery) || item.author.includes(searchQuery);
-		return matchExhibition && matchCategory && matchSearch;
+		return matchUniv && matchDept && matchSearch;
 	});
 
 	return (
@@ -42,16 +38,16 @@ export default function ArtworksClient({
 				searchPlaceholder="작품명, 작가 명을 검색해요."
 			>
 				<FilterChip
-					label="전시"
-					options={exhibitions}
-					selected={selectedExhibition}
-					onSelect={setSelectedExhibition}
+					label="대학"
+					options={univs}
+					selected={selectedUniv}
+					onSelect={setSelectedUniv}
 				/>
 				<FilterChip
-					label="카테고리"
-					options={categories}
-					selected={selectedCategory}
-					onSelect={setSelectedCategory}
+					label="학과"
+					options={depts}
+					selected={selectedDept}
+					onSelect={setSelectedDept}
 				/>
 			</CollapsingHeader>
 

--- a/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
+++ b/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
@@ -7,6 +7,7 @@ import { CollapsingHeader } from "@/components/common/CollapsingHeader/Collapsin
 import { EmptyState } from "@/components/common/EmptyState/EmptyState";
 import { FilterChip } from "@/components/common/FilterChip/FilterChip";
 import MainFooter from "@/components/common/Footer/MainFooter";
+import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 
 interface ArtworksClientProps {
 	artworks: CardItem[];
@@ -17,16 +18,27 @@ export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProp
 	const [searchQuery, setSearchQuery] = useState("");
 	const [selectedUniv, setSelectedUniv] = useState<string | null>(null);
 	const [selectedDept, setSelectedDept] = useState<string | null>(null);
+	const [selectedType, setSelectedType] = useState<string | null>(null);
 
 	const univs = [...new Set(artworks.map((a) => a.univName).filter(Boolean))] as string[];
 	const depts = [...new Set(artworks.map((a) => a.deptName).filter(Boolean))] as string[];
+	const types = [
+		...new Set(
+			artworks
+				.map((a) => a.exhibitionType)
+				.filter((t): t is string => t !== null && t !== undefined)
+				.map((t) => EXHIBITION_TYPE_LABEL[t] ?? t),
+		),
+	];
 
 	const filtered = artworks.filter((item) => {
 		const matchUniv = !selectedUniv || item.univName === selectedUniv;
 		const matchDept = !selectedDept || item.deptName === selectedDept;
+		const typeLabel = EXHIBITION_TYPE_LABEL[item.exhibitionType ?? ""] ?? item.exhibitionType;
+		const matchType = !selectedType || typeLabel === selectedType;
 		const matchSearch =
 			!searchQuery || item.title.includes(searchQuery) || item.author.includes(searchQuery);
-		return matchUniv && matchDept && matchSearch;
+		return matchUniv && matchDept && matchType && matchSearch;
 	});
 
 	return (
@@ -48,6 +60,12 @@ export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProp
 					options={depts}
 					selected={selectedDept}
 					onSelect={setSelectedDept}
+				/>
+				<FilterChip
+					label="유형"
+					options={types}
+					selected={selectedType}
+					onSelect={setSelectedType}
 				/>
 			</CollapsingHeader>
 

--- a/apps/client/app/(main)/artworks/page.tsx
+++ b/apps/client/app/(main)/artworks/page.tsx
@@ -7,7 +7,10 @@ export default async function ArtworksPage() {
 	const [artworks, exhibitions] = await Promise.all([getArtworks(), getExhibitions()]);
 
 	const exhibitionMap = Object.fromEntries(
-		exhibitions.map((e) => [e.id, { univName: e.univName, deptName: e.deptName }]),
+		exhibitions.map((e) => [
+			e.id,
+			{ univName: e.univName, deptName: e.deptName, exhibitionType: e.exhibitionType },
+		]),
 	);
 
 	const displayArtworks =
@@ -21,6 +24,7 @@ export default async function ArtworksPage() {
 					exhibitionTitle: a.exhibitionTitle,
 					univName: exhibitionMap[a.exhibitionId]?.univName,
 					deptName: exhibitionMap[a.exhibitionId]?.deptName,
+					exhibitionType: exhibitionMap[a.exhibitionId]?.exhibitionType ?? undefined,
 				}))
 			: [
 					...new Map(

--- a/apps/client/app/(main)/artworks/page.tsx
+++ b/apps/client/app/(main)/artworks/page.tsx
@@ -1,9 +1,14 @@
 import { getArtworks } from "@/lib/api/artwork";
+import { getExhibitions } from "@/lib/api/exhibition";
 import { CATEGORIES, MOCK_ARTWORKS } from "../_mocks/artwork";
 import ArtworksClient from "./_components/ArtworksClient";
 
 export default async function ArtworksPage() {
-	const artworks = await getArtworks();
+	const [artworks, exhibitions] = await Promise.all([getArtworks(), getExhibitions()]);
+
+	const exhibitionMap = Object.fromEntries(
+		exhibitions.map((e) => [e.id, { univName: e.univName, deptName: e.deptName }]),
+	);
 
 	const displayArtworks =
 		artworks.length > 0
@@ -14,6 +19,8 @@ export default async function ArtworksPage() {
 					author: a.artistName,
 					category: a.category,
 					exhibitionTitle: a.exhibitionTitle,
+					univName: exhibitionMap[a.exhibitionId]?.univName,
+					deptName: exhibitionMap[a.exhibitionId]?.deptName,
 				}))
 			: [
 					...new Map(
@@ -23,26 +30,7 @@ export default async function ArtworksPage() {
 					).values(),
 				];
 
-	const exhibitions = [...new Set(artworks.map((a) => a.exhibitionTitle).filter(Boolean))].sort(
-		(a, b) => a.localeCompare(b, "ko"),
-	);
-
-	const categories = [
-		...new Set(
-			artworks.length > 0
-				? artworks.map((a) => a.category).filter((c): c is string => !!c)
-				: CATEGORIES.filter((c) => c !== "전체"),
-		),
-	].sort((a, b) => a.localeCompare(b, "ko"));
-
 	const slugMap = Object.fromEntries(artworks.map((a) => [a.id, a.slug]));
 
-	return (
-		<ArtworksClient
-			artworks={displayArtworks}
-			exhibitions={exhibitions}
-			categories={categories}
-			slugMap={slugMap}
-		/>
-	);
+	return <ArtworksClient artworks={displayArtworks} slugMap={slugMap} />;
 }

--- a/apps/client/app/(main)/exhibitions/_components/ExhibitionsClient.tsx
+++ b/apps/client/app/(main)/exhibitions/_components/ExhibitionsClient.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "@/components/common/EmptyState/EmptyState";
 import { FilterChip } from "@/components/common/FilterChip/FilterChip";
 import MainFooter from "@/components/common/Footer/MainFooter";
 import type { ExhibitionItem } from "@/lib/api/exhibition";
+import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 import ExhibitionCard from "../../_components/ExhibitionCard";
 
 interface ExhibitionsClientProps {
@@ -17,15 +18,26 @@ export default function ExhibitionsClient({ exhibitions }: ExhibitionsClientProp
 	const [searchQuery, setSearchQuery] = useState("");
 	const [selectedUniv, setSelectedUniv] = useState<string | null>(null);
 	const [selectedDept, setSelectedDept] = useState<string | null>(null);
+	const [selectedType, setSelectedType] = useState<string | null>(null);
 
 	const univs = [...new Set(exhibitions.map((e) => e.univName))];
 	const depts = [...new Set(exhibitions.map((e) => e.deptName))];
+	const types = [
+		...new Set(
+			exhibitions
+				.map((e) => e.exhibitionType)
+				.filter((t): t is string => t !== null)
+				.map((t) => EXHIBITION_TYPE_LABEL[t] ?? t),
+		),
+	];
 
 	const filtered = exhibitions.filter((e) => {
 		const matchSearch = e.title.includes(searchQuery);
 		const matchUniv = !selectedUniv || e.univName === selectedUniv;
 		const matchDept = !selectedDept || e.deptName === selectedDept;
-		return matchSearch && matchUniv && matchDept;
+		const typeLabel = EXHIBITION_TYPE_LABEL[e.exhibitionType ?? ""] ?? e.exhibitionType;
+		const matchType = !selectedType || typeLabel === selectedType;
+		return matchSearch && matchUniv && matchDept && matchType;
 	});
 
 	return (
@@ -47,6 +59,12 @@ export default function ExhibitionsClient({ exhibitions }: ExhibitionsClientProp
 					options={depts}
 					selected={selectedDept}
 					onSelect={setSelectedDept}
+				/>
+				<FilterChip
+					label="유형"
+					options={types}
+					selected={selectedType}
+					onSelect={setSelectedType}
 				/>
 			</CollapsingHeader>
 

--- a/apps/client/app/[exhibitionId]/_api/getExhibitionMeta.ts
+++ b/apps/client/app/[exhibitionId]/_api/getExhibitionMeta.ts
@@ -5,6 +5,7 @@ interface ExhibitionMeta {
 	title: string;
 	description: string | null;
 	image: string | null;
+	favicon: string | null;
 }
 
 export async function getExhibitionMeta(exhibitionId: string): Promise<ExhibitionMeta | null> {

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
@@ -8,8 +8,6 @@ interface ExhibitionHostProps {
 }
 
 export function ExhibitionHostSection({ hostInfo, sns }: ExhibitionHostProps) {
-	const paragraphs = hostInfo.description.split("\n\n").filter(Boolean);
-
 	return (
 		<section className="flex flex-col px-4 pb-6">
 			<Title title="주최 기관" />
@@ -22,11 +20,7 @@ export function ExhibitionHostSection({ hostInfo, sns }: ExhibitionHostProps) {
 			<span className="text-body1-bold mt-5 mb-4">{hostInfo.hostName}</span>
 
 			{/* 기관 소개 */}
-			{paragraphs.map((paragraph, index) => (
-				<p key={index} className="text-body1 leading-relaxed mb-7">
-					{paragraph}
-				</p>
-			))}
+			<p className="text-body1 leading-relaxed mb-7 whitespace-pre-line">{hostInfo.description}</p>
 
 			{/* 소셜 링크 */}
 			{sns.length > 0 && (
@@ -46,10 +40,18 @@ interface SocialLinkProps {
 }
 
 function SocialLink({ label, href }: SocialLinkProps) {
+	const isUrl = href.startsWith("http://") || href.startsWith("https://");
+
 	return (
 		<div className="flex flex-wrap items-center gap-1">
 			<span className="min-w-19 text-body2-bold shrink-0">{label}</span>
-			<span className="text-body2">{href}</span>
+			{isUrl ? (
+				<a href={href} target="_blank" rel="noopener noreferrer" className="text-body2">
+					{href}
+				</a>
+			) : (
+				<span className="text-body2">{href}</span>
+			)}
 		</div>
 	);
 }

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
@@ -11,10 +11,15 @@ interface ExhibitionIntroProps {
 }
 
 export function ExhibitionIntroSection({ exhibition, exhibitionId }: ExhibitionIntroProps) {
+	const typeLabel =
+		exhibition.exhibitionType != null
+			? (EXHIBITION_TYPE_LABEL[exhibition.exhibitionType] ?? exhibition.exhibitionType)
+			: null;
+
 	const rows = [
 		{ label: "주최 대학", value: exhibition.univName },
 		{ label: "학과", value: exhibition.deptName },
-		{ label: "유형", value: EXHIBITION_TYPE_LABEL[exhibition.exhibitionType]},
+		...(typeLabel ? [{ label: "유형", value: typeLabel }] : []),
 	];
 
 	return (

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import RowList from "@/components/common/RowList/RowList";
 import { Title } from "@/components/common/Title/Title";
 import type { ExhibitionDetail } from "@/lib/api/exhibition";
+import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 
 interface ExhibitionIntroProps {
 	exhibition: ExhibitionDetail;
@@ -13,6 +14,7 @@ export function ExhibitionIntroSection({ exhibition, exhibitionId }: ExhibitionI
 	const rows = [
 		{ label: "주최 대학", value: exhibition.univName },
 		{ label: "학과", value: exhibition.deptName },
+		{ label: "유형", value: EXHIBITION_TYPE_LABEL[exhibition.exhibitionType]},
 	];
 
 	return (

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import MainFooter from "@/components/common/Footer/MainFooter";
 import SchoolFooter from "@/components/common/Footer/SchoolFooter";
 import { getExhibitions } from "@/lib/api/exhibition";
 import { getExhibitionFooter } from "@/lib/api/layout";
@@ -31,15 +32,6 @@ export async function generateMetadata({
 	};
 }
 
-const MOCK_FOOTER = {
-	title: "흙에서 시작되는 모든 이야기",
-	department: "한국대학교 예술대학 도예과",
-	address: "서울 중구 필동로1길 30",
-	detail_location: "동국대학교 문화관 지하 1층 동국갤러리",
-	email: "dgu_art@dongguk.edu",
-	copyright: "©2025. Dongguk University Sculpture Department Exhibition.",
-};
-
 export default async function ExhibitionLayout({
 	children,
 	params,
@@ -68,7 +60,7 @@ export default async function ExhibitionLayout({
 		}),
 	};
 
-	const footer = uuid ? ((await getExhibitionFooter(uuid)) ?? MOCK_FOOTER) : MOCK_FOOTER;
+	const footer = uuid ? await getExhibitionFooter(uuid) : null;
 
 	const colorVars = {
 		...(config.btnBg && { "--btn-bg": config.btnBg }),
@@ -93,16 +85,19 @@ export default async function ExhibitionLayout({
 				<div className="bg-normal text-strong min-h-dvh flex flex-col" style={colorVars}>
 					<div className="min-h-dvh flex flex-col w-full max-w-135 mx-auto">{children}</div>
 
-					{/* <SchoolFooter logoSrc={config.footerInfo.logoSrc} {...config.footerInfo} /> */}
-					<SchoolFooter
-						logoSrc={config.footerInfo.logoSrc}
-						title={footer.title}
-						department={footer.department}
-						address={footer.address ?? ""}
-						detail_location={footer.detail_location ?? ""}
-						email={footer.email}
-						copyright={footer.copyright ?? ""}
-					/>
+					{footer ? (
+						<SchoolFooter
+							logoSrc={config.footerInfo.logoSrc}
+							title={footer.title}
+							department={footer.department}
+							address={footer.address ?? ""}
+							detail_location={footer.detail_location ?? ""}
+							email={footer.email}
+							copyright={footer.copyright ?? ""}
+						/>
+					) : (
+						<MainFooter />
+					)}
 					<TabBarSpacer />
 				</div>
 			</ThemeProvider>

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -1,12 +1,35 @@
+import type { Metadata } from "next";
 import SchoolFooter from "@/components/common/Footer/SchoolFooter";
 import { getExhibitions } from "@/lib/api/exhibition";
 import { getExhibitionFooter } from "@/lib/api/layout";
 import { ThemeProvider } from "@/providers/theme-providers";
 import { getExhibitionCustom } from "./_api/getExhibitionCustom";
+import { getExhibitionMeta } from "./_api/getExhibitionMeta";
 import { resolveExhibitionId } from "./_api/resolveExhibitionId";
 import { TabBarSpacer } from "./_components/TabBarSpacer";
 import { ExhibitionProvider } from "./_context/ExhibitionContext";
 import { DEFAULT_EXHIBITION_CONFIG } from "./exhibition-config";
+
+export async function generateMetadata({
+	params,
+}: {
+	params: Promise<{ exhibitionId: string }>;
+}): Promise<Metadata> {
+	const { exhibitionId } = await params;
+	const uuid = await resolveExhibitionId(exhibitionId);
+	const meta = uuid ? await getExhibitionMeta(uuid) : null;
+
+	return {
+		title: meta?.title ?? "두록",
+		description: meta?.description ?? "우리의 졸업 전시, 더 오래 기록하는 방법",
+		icons: { icon: meta?.favicon ?? "/favicon.ico" },
+		openGraph: {
+			title: meta?.title ?? "두록",
+			description: meta?.description ?? "우리의 졸업 전시, 더 오래 기록하는 방법",
+			images: meta?.image ? [{ url: meta.image }] : [{ url: "/images/og-default.png" }],
+		},
+	};
+}
 
 const MOCK_FOOTER = {
 	title: "흙에서 시작되는 모든 이야기",

--- a/apps/client/app/[exhibitionId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/page.tsx
@@ -1,8 +1,6 @@
-import type { Metadata } from "next";
 import Image from "next/image";
 import { Divider } from "@/components/common/Divider/Divider";
 import { getExhibitionDetail, getExhibitionHost, getHostSns } from "@/lib/api/exhibition";
-import { getExhibitionMeta } from "./_api/getExhibitionMeta";
 import { resolveExhibitionId } from "./_api/resolveExhibitionId";
 import { ExhibitionDetailSection } from "./_components/ExhibitionDetailSection";
 import { ExhibitionHostSection } from "./_components/ExhibitionHostSection";
@@ -13,22 +11,6 @@ import { MOCK_EXHIBITION_DETAIL, MOCK_EXHIBITION_HOST, MOCK_HOST_SNS } from "./_
 
 interface ExhibitionDetailPageProps {
 	params: Promise<{ exhibitionId: string }>;
-}
-
-export async function generateMetadata({ params }: ExhibitionDetailPageProps): Promise<Metadata> {
-	const { exhibitionId } = await params;
-	const uuid = await resolveExhibitionId(exhibitionId);
-	const meta = uuid ? await getExhibitionMeta(uuid) : null;
-
-	return {
-		title: meta?.title,
-		description: meta?.description,
-		openGraph: {
-			title: meta?.title,
-			description: meta?.description ?? undefined,
-			images: meta?.image ? [{ url: meta.image }] : [],
-		},
-	};
 }
 
 export default async function ExhibitionDetailPage({ params }: ExhibitionDetailPageProps) {

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -4,9 +4,10 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
 	title: "두록",
 	description: "우리의 졸업 전시, 더 오래 기록하는 방법",
-	//TODO: 추후 연결 도메인으로 변경 필요
 	metadataBase: new URL("https://dolog.kr"),
 	openGraph: {
+		type: "website",
+		url: "https://dolog.kr",
 		title: "두록",
 		description: "우리의 졸업 전시, 더 오래 기록하는 방법",
 		images: [{ url: "/images/og-default.png" }],

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -5,7 +5,7 @@ export const metadata: Metadata = {
 	title: "두록",
 	description: "우리의 졸업 전시, 더 오래 기록하는 방법",
 	//TODO: 추후 연결 도메인으로 변경 필요
-	metadataBase: new URL("https://dolog.netlify.app"),
+	metadataBase: new URL("https://dolog.kr"),
 	openGraph: {
 		title: "두록",
 		description: "우리의 졸업 전시, 더 오래 기록하는 방법",

--- a/apps/client/components/common/Card/Card.types.ts
+++ b/apps/client/components/common/Card/Card.types.ts
@@ -7,6 +7,7 @@ export interface CardItem {
 	exhibitionTitle?: string;
 	univName?: string;
 	deptName?: string;
+	exhibitionType?: string;
 }
 
 export interface CardProps extends Omit<CardItem, "id"> {}

--- a/apps/client/components/common/Card/Card.types.ts
+++ b/apps/client/components/common/Card/Card.types.ts
@@ -5,6 +5,8 @@ export interface CardItem {
 	category?: string;
 	author: string;
 	exhibitionTitle?: string;
+	univName?: string;
+	deptName?: string;
 }
 
 export interface CardProps extends Omit<CardItem, "id"> {}

--- a/apps/client/components/common/Card/RowCard/RowCard.tsx
+++ b/apps/client/components/common/Card/RowCard/RowCard.tsx
@@ -6,16 +6,21 @@ import type { RowCardProps } from "./RowCard.types";
 export const RowCard = ({ name, engName, email, imageUrl }: RowCardProps) => {
 	return (
 		<article className={s.wrapper}>
-			{/* 이미지 -  TODO: default 이미지 임시로 넣어둠*/}
 			<div className={s.imageWrapper}>
-				<Image
-					src={imageUrl ?? "/images/artists/artist2.png"}
-					alt={`${name} ${engName}`}
-					width={72}
-					height={96}
-					className={s.image}
-					unoptimized
-				/>
+				{imageUrl ? (
+					<Image
+						src={imageUrl}
+						alt={`${name} ${engName}`}
+						width={72}
+						height={96}
+						className={s.image}
+						unoptimized
+					/>
+				) : (
+					<div className="w-full h-full bg-fg-lighter flex items-center justify-center">
+						<Image src="/icons/empty-image.svg" alt="이미지 없음" width={32} height={32} />
+					</div>
+				)}
 			</div>
 
 			{/* 텍스트 */}

--- a/apps/client/lib/api/exhibition.ts
+++ b/apps/client/lib/api/exhibition.ts
@@ -13,6 +13,7 @@ export interface ExhibitionItem {
 	title: string;
 	univName: string;
 	deptName: string;
+	exhibitionType: string | null;
 	imageUrl: string | null;
 	logoImg: string;
 	startDate: string | null;

--- a/apps/client/lib/api/exhibition.ts
+++ b/apps/client/lib/api/exhibition.ts
@@ -13,7 +13,7 @@ export interface ExhibitionItem {
 	title: string;
 	univName: string;
 	deptName: string;
-	exhibitionType: string | null;
+	exhibitionType?: string | null;
 	imageUrl: string | null;
 	logoImg: string;
 	startDate: string | null;
@@ -87,7 +87,7 @@ export interface ExhibitionDetail {
 	exhibitionId: string;
 	univName: string;
 	deptName: string;
-	exhibitionType: string;
+	exhibitionType?: string | null;
 	title: string;
 	exhibitionImg: string;
 	startDate: string;

--- a/apps/client/lib/api/exhibition.ts
+++ b/apps/client/lib/api/exhibition.ts
@@ -87,6 +87,7 @@ export interface ExhibitionDetail {
 	exhibitionId: string;
 	univName: string;
 	deptName: string;
+	exhibitionType: string;
 	title: string;
 	exhibitionImg: string;
 	startDate: string;

--- a/apps/client/lib/constants/exhibition.ts
+++ b/apps/client/lib/constants/exhibition.ts
@@ -1,0 +1,4 @@
+export const EXHIBITION_TYPE_LABEL: Record<string, string> = {
+	assignment: "과제전",
+	graduation: "졸업전시전",
+};


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

 ### 메타데이터                                                                
  - OG 이미지 경로 수정                                                         
  - `generateMetadata`를 `layout.tsx`로 이동하여 전시별 메타데이터 적용 범위 확대                                                                          
  - 전시별 파비콘 동적 적용 추가                                                
                                                                                
  ### 전시 목록 / 작품 목록 필터                                                
  - 전체 작품 페이지 필터칩: 전시/카테고리 → 대학/학과/유형으로 변경            
  - 전체 전시 페이지 필터칩: 유형 필터 추가                                     
  - `exhibitionType` 영문값 한글 라벨로 변환 (`assignment` → 과제전, `graduation` → 졸업전시전)                                                    
                                                                                
  ### 전시 상세 페이지
  - 기본 정보 섹션에 유형 행 추가 (값 없을 시 미노출)                           
  - host SNS 링크 클릭 시 외부 페이지로 이동 (http/https URL만 적용)            
  - mock footer 데이터 제거                                                     
                                                                                
  ### 기타                                                                      
  - 메인 배너 새 창에서 열리도록 수정
  - 도움을 주신 분들 섹션 디폴트 이미지 수정  

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

  - `exhibitionType`은 optional 처리 (`string | null | undefined`) — 값 없을 시 해당 UI 미노출
  - SNS 링크는 `http://` 또는 `https://`로 시작하는 경우에만 `<a>` 태그로 렌더링


## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #74
