### PR TITLE
refactor: 헤더 뒤로가기 예외 처리 및 material 줄바꿈

### DIFF
--- a/apps/client/app/[exhibitionId]/_components/Header.tsx
+++ b/apps/client/app/[exhibitionId]/_components/Header.tsx
@@ -20,6 +20,21 @@ export const Header = ({ variant = "logo", title }: HeaderProps) => {
 
 	const baseUrl = `/${slug}`;
 
+	const handleBack = () => {
+		const historyLength = window?.history?.length ?? 0;
+		const referrer = document?.referrer ?? "";
+		const host = window?.location?.host ?? "";
+
+		// 이전 기록이 없거나, 이전 페이지가 우리 서비스 도메인이 아닌 경우
+		const hasNoReferrer = !referrer || !referrer.includes(host);
+
+		if (historyLength <= 1 || hasNoReferrer) {
+			router.push(baseUrl);
+		} else {
+			router.back();
+		}
+	};
+
 	return (
 		<>
 			<header className="sticky top-0 z-51 flex items-center justify-between px-4 py-3 h-11 border-b border-stroke-lightest bg-normal">
@@ -27,7 +42,7 @@ export const Header = ({ variant = "logo", title }: HeaderProps) => {
 					<div className="flex items-center gap-2">
 						<button
 							type="button"
-							onClick={() => router.back()}
+							onClick={handleBack}
 							aria-label="뒤로가기"
 							className="cursor-pointer"
 						>
@@ -50,7 +65,6 @@ export const Header = ({ variant = "logo", title }: HeaderProps) => {
 						) : (
 							<Image src="/images/exhibitionLogo.svg" alt="DoLog" width={34} height={24} priority />
 						)}
-						{/* TODO : 기본 로고 fallback 제거 예정 */}
 					</button>
 				)}
 				<button

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/InfoSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/InfoSection.tsx
@@ -33,7 +33,7 @@ export const InfoSection = ({ data }: InfoSectionProps) => {
 
 				{/* 작품 재료, 작품 사이즈 - 선택값 */}
 				{(data.material || data.size) && (
-					<p className="text-body1 mt-1">
+					<p className="text-body1 mt-1 whitespace-pre-line">
 						{[data.material, data.size].filter(Boolean).join(" | ")}
 					</p>
 				)}


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

- 헤더(Header)의 뒤로가기 버튼(back) 동작 예외 처리 추가
- 브라우저 히스토리가 없거나 외부 사이트에서 직접 유입되어 뒤로 갈 페이지가 없는 경우, 현재 전시의 메인 화면(/${slug})으로 리다이렉트되도록 개선

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

- window.history.length를 사용하여 진입점인지 확인합니다.
- 외부 사이트(구글, 네이버 등)에서 링크를 타고 직접 진입한 경우를 대비해 document.referrer와 현재 host를 비교하여 외부 유입 시에도 안전하게 서비스 내부 메인(baseUrl)으로 이동하도록 처리했습니다.
- Biome 린터 경고(biomelint/complexity/useOptionalChain)를 해결하기 위해 window 및 document 객체 접근 시 옵셔널 체이닝(?.)과 널 병합 연산자(??)를 적용했습니다.

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`Header`

- handleBack 함수를 신설하여 뒤로가기 버튼 클릭 시 히스토리 유무와 외부 유입 여부를 먼저 스크리닝한 뒤 router.push 또는 router.back을 실행합니다.

```typescript
const handleBack = () => {
  const historyLength = window?.history?.length ?? 0;
  const referrer = document?.referrer ?? "";
  const host = window?.location?.host ?? "";

  // 이전 기록이 없거나, 이전 페이지가 우리 서비스 도메인이 아닌 경우 (외부 유입 예외 처리)
  const hasNoReferrer = !referrer || !referrer.includes(host);

  if (historyLength <= 1 || hasNoReferrer) {
    router.push(baseUrl);
  } else {
    router.back();
  }
};
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #74
