### PR TITLE
feat: amplitude 연결

### DIFF
--- a/apps/client/app/(main)/_components/Banner.tsx
+++ b/apps/client/app/(main)/_components/Banner.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRef, useState } from "react";
+import { track } from "@/lib/amplitude";
 import type { BannerItem } from "@/lib/api/exhibition";
 
 const MAX_BANNERS = 20;
@@ -20,7 +21,6 @@ export default function Banner({ banners }: { banners: BannerItem[] }) {
 
 	return (
 		<section aria-label="배너 슬라이드" className="flex flex-col overflow-hidden">
-			{/* slide */}
 			{/* biome-ignore lint/a11y/noNoninteractiveElementInteractions: carousel swipe */}
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: carousel swipe */}
 			<div
@@ -70,6 +70,14 @@ export default function Banner({ banners }: { banners: BannerItem[] }) {
 							className="relative min-w-full h-full block"
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={() =>
+								track("Banner Clicked", {
+									banner_id: banner.id,
+									banner_index: banner.orderIndex,
+									banner_url: banner.linkUrl,
+									position: i,
+								})
+							}
 						>
 							{banner.imageUrl && (
 								<Image

--- a/apps/client/app/(main)/_components/CategorySection.tsx
+++ b/apps/client/app/(main)/_components/CategorySection.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useState } from "react";
 import type { CardItem } from "@/components/common/Card/Card.types";
 import { CardGrid } from "@/components/common/Card/CardGrid";
+// import { Chip } from "@/components/common/Chip/Chip";
 import { Title } from "@/components/common/Title/Title";
 import { track } from "@/lib/amplitude";
 
@@ -22,6 +23,20 @@ export default function CategorySection({ title, categories, artworks, slugMap }
 		<section className="flex flex-col px-4 pt-6">
 			<Title title={title} />
 
+			{/* 카테고리 칩 */}
+			{/* <div className="flex gap-2 mt-4 overflow-x-auto pb-1 scrollbar-hide">
+				{categories.map((category) => (
+					<Chip
+						key={category}
+						label={category}
+						selected={selected === category}
+						type="assistive"
+						onClick={() => setSelected(category)}
+					/>
+				))}
+			</div> */}
+
+			{/* 작품 그리드 */}
 			<div className="mt-4">
 				<CardGrid
 					items={artworks[selected] ?? []}

--- a/apps/client/app/(main)/_components/CategorySection.tsx
+++ b/apps/client/app/(main)/_components/CategorySection.tsx
@@ -5,8 +5,8 @@ import Link from "next/link";
 import { useState } from "react";
 import type { CardItem } from "@/components/common/Card/Card.types";
 import { CardGrid } from "@/components/common/Card/CardGrid";
-// import { Chip } from "@/components/common/Chip/Chip";
 import { Title } from "@/components/common/Title/Title";
+import { track } from "@/lib/amplitude";
 
 interface Props {
 	title: string;
@@ -22,20 +22,6 @@ export default function CategorySection({ title, categories, artworks, slugMap }
 		<section className="flex flex-col px-4 pt-6">
 			<Title title={title} />
 
-			{/* 카테고리 칩 */}
-			{/* <div className="flex gap-2 mt-4 overflow-x-auto pb-1 scrollbar-hide">
-				{categories.map((category) => (
-					<Chip
-						key={category}
-						label={category}
-						selected={selected === category}
-						type="assistive"
-						onClick={() => setSelected(category)}
-					/>
-				))}
-			</div> */}
-
-			{/* 작품 그리드 */}
 			<div className="mt-4">
 				<CardGrid
 					items={artworks[selected] ?? []}
@@ -48,6 +34,13 @@ export default function CategorySection({ title, categories, artworks, slugMap }
 								}
 							: undefined
 					}
+					onItemClick={(item) =>
+						track("Artwork Card Clicked", {
+							artwork_id: item.id,
+							artwork_title: item.title,
+							page: "main",
+						})
+					}
 				/>
 			</div>
 
@@ -57,6 +50,7 @@ export default function CategorySection({ title, categories, artworks, slugMap }
 					variant: "assistive",
 					className: "mt-7 mb-6 w-full",
 				})}
+				onClick={() => track("More Button Clicked", { target: "artworks", page: "main" })}
 			>
 				더보기
 			</Link>

--- a/apps/client/app/(main)/_components/Header.tsx
+++ b/apps/client/app/(main)/_components/Header.tsx
@@ -1,11 +1,19 @@
+"use client";
+
 import { Button } from "components";
 import Image from "next/image";
+import { track } from "@/lib/amplitude";
 
 export const Header = () => {
 	return (
 		<header className="flex items-center justify-between px-4 py-3">
 			<Image src="/images/logo.svg" alt="DoLog" width={47} height={20} priority />
-			<a href="https://www.instagram.com/dolog.archive/" target="_blank" rel="noopener noreferrer">
+			<a
+				href="https://www.instagram.com/dolog.archive/"
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={() => track("Button Clicked", { button: "문의하기", page: "main" })}
+			>
 				<Button variant="assistive" size="sm">
 					문의하기
 				</Button>

--- a/apps/client/app/(main)/_components/TrackedExhibitionLink.tsx
+++ b/apps/client/app/(main)/_components/TrackedExhibitionLink.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+import { track } from "@/lib/amplitude";
+
+interface Props {
+	href: string;
+	exhibitionId: string | number;
+	exhibitionTitle?: string;
+	children: React.ReactNode;
+}
+
+export function TrackedExhibitionLink({ href, exhibitionId, exhibitionTitle, children }: Props) {
+	return (
+		<Link
+			href={href}
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={() =>
+				track("Exhibition Card Clicked", {
+					exhibition_id: exhibitionId,
+					exhibition_title: exhibitionTitle,
+					page: "main",
+				})
+			}
+		>
+			{children}
+		</Link>
+	);
+}

--- a/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
+++ b/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
@@ -59,7 +59,8 @@ export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProp
 					selected={selectedUniv}
 					onSelect={(val) => {
 						setSelectedUniv(val);
-						if (val) track("Filter Selected", { filter_type: "univ", value: val, page: "artworks_list" });
+						if (val)
+							track("Filter Selected", { filter_type: "univ", value: val, page: "artworks_list" });
 					}}
 				/>
 				<FilterChip
@@ -68,7 +69,8 @@ export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProp
 					selected={selectedDept}
 					onSelect={(val) => {
 						setSelectedDept(val);
-						if (val) track("Filter Selected", { filter_type: "dept", value: val, page: "artworks_list" });
+						if (val)
+							track("Filter Selected", { filter_type: "dept", value: val, page: "artworks_list" });
 					}}
 				/>
 				<FilterChip
@@ -77,7 +79,8 @@ export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProp
 					selected={selectedType}
 					onSelect={(val) => {
 						setSelectedType(val);
-						if (val) track("Filter Selected", { filter_type: "type", value: val, page: "artworks_list" });
+						if (val)
+							track("Filter Selected", { filter_type: "type", value: val, page: "artworks_list" });
 					}}
 				/>
 			</CollapsingHeader>

--- a/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
+++ b/apps/client/app/(main)/artworks/_components/ArtworksClient.tsx
@@ -7,6 +7,8 @@ import { CollapsingHeader } from "@/components/common/CollapsingHeader/Collapsin
 import { EmptyState } from "@/components/common/EmptyState/EmptyState";
 import { FilterChip } from "@/components/common/FilterChip/FilterChip";
 import MainFooter from "@/components/common/Footer/MainFooter";
+import { PageTracker } from "@/components/common/PageTracker";
+import { track } from "@/lib/amplitude";
 import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 
 interface ArtworksClientProps {
@@ -44,6 +46,7 @@ export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProp
 
 	return (
 		<div className="flex flex-col min-h-screen">
+			<PageTracker pageName="artworks_list" />
 			<CollapsingHeader
 				title="전체 작품"
 				searchQuery={searchQuery}
@@ -54,19 +57,28 @@ export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProp
 					label="대학"
 					options={univs}
 					selected={selectedUniv}
-					onSelect={setSelectedUniv}
+					onSelect={(val) => {
+						setSelectedUniv(val);
+						if (val) track("Filter Selected", { filter_type: "univ", value: val, page: "artworks_list" });
+					}}
 				/>
 				<FilterChip
 					label="학과"
 					options={depts}
 					selected={selectedDept}
-					onSelect={setSelectedDept}
+					onSelect={(val) => {
+						setSelectedDept(val);
+						if (val) track("Filter Selected", { filter_type: "dept", value: val, page: "artworks_list" });
+					}}
 				/>
 				<FilterChip
 					label="유형"
 					options={types}
 					selected={selectedType}
-					onSelect={setSelectedType}
+					onSelect={(val) => {
+						setSelectedType(val);
+						if (val) track("Filter Selected", { filter_type: "type", value: val, page: "artworks_list" });
+					}}
 				/>
 			</CollapsingHeader>
 
@@ -78,6 +90,13 @@ export default function ArtworksClient({ artworks, slugMap }: ArtworksClientProp
 							const slug = slugMap?.[String(item.id)];
 							return slug ? `/${slug}/artwork/${item.id}` : "#";
 						}}
+						onItemClick={(item) =>
+							track("Artwork Card Clicked", {
+								artwork_id: item.id,
+								artwork_title: item.title,
+								page: "artworks_list",
+							})
+						}
 					/>
 				) : (
 					<EmptyState searchQuery={searchQuery} message="해당하는 작품이 없어요." />

--- a/apps/client/app/(main)/exhibitions/_components/ExhibitionsClient.tsx
+++ b/apps/client/app/(main)/exhibitions/_components/ExhibitionsClient.tsx
@@ -7,8 +7,8 @@ import { FilterChip } from "@/components/common/FilterChip/FilterChip";
 import MainFooter from "@/components/common/Footer/MainFooter";
 import { PageTracker } from "@/components/common/PageTracker";
 import { TrackedLink } from "@/components/common/TrackedLink";
-import type { ExhibitionItem } from "@/lib/api/exhibition";
 import { track } from "@/lib/amplitude";
+import type { ExhibitionItem } from "@/lib/api/exhibition";
 import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 import ExhibitionCard from "../../_components/ExhibitionCard";
 
@@ -57,7 +57,12 @@ export default function ExhibitionsClient({ exhibitions }: ExhibitionsClientProp
 					selected={selectedUniv}
 					onSelect={(val) => {
 						setSelectedUniv(val);
-						if (val) track("Filter Selected", { filter_type: "univ", value: val, page: "exhibitions_list" });
+						if (val)
+							track("Filter Selected", {
+								filter_type: "univ",
+								value: val,
+								page: "exhibitions_list",
+							});
 					}}
 				/>
 				<FilterChip
@@ -66,7 +71,12 @@ export default function ExhibitionsClient({ exhibitions }: ExhibitionsClientProp
 					selected={selectedDept}
 					onSelect={(val) => {
 						setSelectedDept(val);
-						if (val) track("Filter Selected", { filter_type: "dept", value: val, page: "exhibitions_list" });
+						if (val)
+							track("Filter Selected", {
+								filter_type: "dept",
+								value: val,
+								page: "exhibitions_list",
+							});
 					}}
 				/>
 				<FilterChip
@@ -75,7 +85,12 @@ export default function ExhibitionsClient({ exhibitions }: ExhibitionsClientProp
 					selected={selectedType}
 					onSelect={(val) => {
 						setSelectedType(val);
-						if (val) track("Filter Selected", { filter_type: "type", value: val, page: "exhibitions_list" });
+						if (val)
+							track("Filter Selected", {
+								filter_type: "type",
+								value: val,
+								page: "exhibitions_list",
+							});
 					}}
 				/>
 			</CollapsingHeader>
@@ -87,7 +102,11 @@ export default function ExhibitionsClient({ exhibitions }: ExhibitionsClientProp
 							key={exhibition.id}
 							href={`/${exhibition.slug || exhibition.id}`}
 							eventName="Exhibition Card Clicked"
-							eventProps={{ exhibition_id: exhibition.id, exhibition_title: exhibition.title, page: "exhibitions_list" }}
+							eventProps={{
+								exhibition_id: exhibition.id,
+								exhibition_title: exhibition.title,
+								page: "exhibitions_list",
+							}}
 						>
 							<ExhibitionCard {...exhibition} />
 						</TrackedLink>

--- a/apps/client/app/(main)/exhibitions/_components/ExhibitionsClient.tsx
+++ b/apps/client/app/(main)/exhibitions/_components/ExhibitionsClient.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import Link from "next/link";
 import { useState } from "react";
 import { CollapsingHeader } from "@/components/common/CollapsingHeader/CollapsingHeader";
 import { EmptyState } from "@/components/common/EmptyState/EmptyState";
 import { FilterChip } from "@/components/common/FilterChip/FilterChip";
 import MainFooter from "@/components/common/Footer/MainFooter";
+import { PageTracker } from "@/components/common/PageTracker";
+import { TrackedLink } from "@/components/common/TrackedLink";
 import type { ExhibitionItem } from "@/lib/api/exhibition";
+import { track } from "@/lib/amplitude";
 import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 import ExhibitionCard from "../../_components/ExhibitionCard";
 
@@ -42,6 +44,7 @@ export default function ExhibitionsClient({ exhibitions }: ExhibitionsClientProp
 
 	return (
 		<div className="flex flex-col min-h-screen">
+			<PageTracker pageName="exhibitions_list" />
 			<CollapsingHeader
 				title="전체 전시"
 				searchQuery={searchQuery}
@@ -52,29 +55,42 @@ export default function ExhibitionsClient({ exhibitions }: ExhibitionsClientProp
 					label="대학"
 					options={univs}
 					selected={selectedUniv}
-					onSelect={setSelectedUniv}
+					onSelect={(val) => {
+						setSelectedUniv(val);
+						if (val) track("Filter Selected", { filter_type: "univ", value: val, page: "exhibitions_list" });
+					}}
 				/>
 				<FilterChip
 					label="학과"
 					options={depts}
 					selected={selectedDept}
-					onSelect={setSelectedDept}
+					onSelect={(val) => {
+						setSelectedDept(val);
+						if (val) track("Filter Selected", { filter_type: "dept", value: val, page: "exhibitions_list" });
+					}}
 				/>
 				<FilterChip
 					label="유형"
 					options={types}
 					selected={selectedType}
-					onSelect={setSelectedType}
+					onSelect={(val) => {
+						setSelectedType(val);
+						if (val) track("Filter Selected", { filter_type: "type", value: val, page: "exhibitions_list" });
+					}}
 				/>
 			</CollapsingHeader>
 
-			{/* 전시회 목록 */}
 			<section className="flex flex-col flex-1 px-4 gap-4">
 				{filtered.length > 0 ? (
 					filtered.map((exhibition) => (
-						<Link key={exhibition.id} href={`/${exhibition.slug || exhibition.id}`}>
+						<TrackedLink
+							key={exhibition.id}
+							href={`/${exhibition.slug || exhibition.id}`}
+							eventName="Exhibition Card Clicked"
+							eventProps={{ exhibition_id: exhibition.id, exhibition_title: exhibition.title, page: "exhibitions_list" }}
+						>
 							<ExhibitionCard {...exhibition} />
-						</Link>
+						</TrackedLink>
 					))
 				) : (
 					<EmptyState searchQuery={searchQuery} />

--- a/apps/client/app/(main)/page.tsx
+++ b/apps/client/app/(main)/page.tsx
@@ -1,14 +1,16 @@
 import { buttonVariants } from "components";
-import Link from "next/link";
 import { Divider } from "@/components/common/Divider/Divider";
 import MainFooter from "@/components/common/Footer/MainFooter";
+import { PageTracker } from "@/components/common/PageTracker";
 import { Title } from "@/components/common/Title/Title";
+import { TrackedLink } from "@/components/common/TrackedLink";
 import { getMainArtworks } from "@/lib/api/artwork";
 import { getBanners, getMainExhibitions } from "@/lib/api/exhibition";
 import Banner from "./_components/Banner";
 import CategorySection from "./_components/CategorySection";
 import ExhibitionCard from "./_components/ExhibitionCard";
 import { Header } from "./_components/Header";
+import { TrackedExhibitionLink } from "./_components/TrackedExhibitionLink";
 import { MOCK_BANNERS } from "./_mocks/banner";
 import { MOCK_EXHIBITIONS } from "./_mocks/exhibition";
 import { MOCK_SECTIONS } from "./_mocks/section";
@@ -32,6 +34,7 @@ export default async function MainPage() {
 
 	return (
 		<div className="flex flex-col">
+			<PageTracker pageName="main" />
 			<Header />
 			<Banner banners={displayBanners} />
 
@@ -39,25 +42,24 @@ export default async function MainPage() {
 				<Title title="진행 중인 전시" />
 				<div className="flex flex-col gap-4 mt-4">
 					{displayExhibitions.slice(0, 3).map((exhibition) => (
-						<Link
+						<TrackedExhibitionLink
 							key={exhibition.id}
 							href={`/${exhibition.slug ?? exhibition.id}`}
-							target="_blank"
-							rel="noopener noreferrer"
+							exhibitionId={exhibition.id}
+							exhibitionTitle={exhibition.title}
 						>
 							<ExhibitionCard {...exhibition} />
-						</Link>
+						</TrackedExhibitionLink>
 					))}
 				</div>
-				<Link
+				<TrackedLink
 					href="/exhibitions"
-					className={buttonVariants({
-						variant: "assistive",
-						className: "mt-7 w-full",
-					})}
+					eventName="More Button Clicked"
+					eventProps={{ target: "exhibitions", page: "main" }}
+					className={buttonVariants({ variant: "assistive", className: "mt-7 w-full" })}
 				>
 					더보기
-				</Link>
+				</TrackedLink>
 			</section>
 
 			<Divider fullBleed={false} />

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionDetailSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionDetailSection.tsx
@@ -23,7 +23,7 @@ export function ExhibitionDetailSection({ exhibition }: ExhibitionDetailProps) {
 	];
 
 	return (
-		<section className="flex flex-col px-4 pb-6">
+		<section className="flex flex-col px-4 pb-6" data-section="detail">
 			<Title title="전시 소개" />
 			<div className="flex flex-col gap-2 mb-4">
 				<RowList rows={rows} />

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Image from "next/image";
 import { Title } from "@/components/common/Title/Title";
+import { track } from "@/lib/amplitude";
 import type { ExhibitionHost, HostSns } from "@/lib/api/exhibition";
 
 interface ExhibitionHostProps {
@@ -9,24 +12,24 @@ interface ExhibitionHostProps {
 
 export function ExhibitionHostSection({ hostInfo, sns }: ExhibitionHostProps) {
 	return (
-		<section className="flex flex-col px-4 pb-6">
+		<section className="flex flex-col px-4 pb-6" data-section="host">
 			<Title title="주최 기관" />
 
-			{/* 이미지 */}
 			<div className="relative w-full aspect-video overflow-hidden">
 				<Image src={hostInfo.hostImageUrl} alt={hostInfo.hostName} fill className="object-cover" />
 			</div>
-			{/* 기관명 */}
 			<span className="text-body1-bold mt-5 mb-4">{hostInfo.hostName}</span>
-
-			{/* 기관 소개 */}
 			<p className="text-body1 leading-relaxed mb-7 whitespace-pre-line">{hostInfo.description}</p>
 
-			{/* 소셜 링크 */}
 			{sns.length > 0 && (
 				<div className="flex flex-col gap-1">
 					{sns.map((link) => (
-						<SocialLink key={link.snsId} label={link.platformName} href={link.url} />
+						<SocialLink
+							key={link.snsId}
+							label={link.platformName}
+							href={link.url}
+							hostName={hostInfo.hostName}
+						/>
 					))}
 				</div>
 			)}
@@ -37,16 +40,25 @@ export function ExhibitionHostSection({ hostInfo, sns }: ExhibitionHostProps) {
 interface SocialLinkProps {
 	label: string;
 	href: string;
+	hostName: string;
 }
 
-function SocialLink({ label, href }: SocialLinkProps) {
+function SocialLink({ label, href, hostName }: SocialLinkProps) {
 	const isUrl = href.startsWith("http://") || href.startsWith("https://");
 
 	return (
 		<div className="flex flex-wrap items-center gap-1">
 			<span className="min-w-19 text-body2-bold shrink-0">{label}</span>
 			{isUrl ? (
-				<a href={href} target="_blank" rel="noopener noreferrer" className="text-body2">
+				<a
+					href={href}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="text-body2"
+					onClick={() =>
+						track("SNS Link Clicked", { platform: label, host: hostName, page: "exhibition_intro" })
+					}
+				>
 					{href}
 				</a>
 			) : (

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { Button } from "components";
 import Link from "next/link";
+import { useRef } from "react";
 import RowList from "@/components/common/RowList/RowList";
 import { Title } from "@/components/common/Title/Title";
+import { track } from "@/lib/amplitude";
 import type { ExhibitionDetail } from "@/lib/api/exhibition";
 import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 
@@ -11,6 +15,8 @@ interface ExhibitionIntroProps {
 }
 
 export function ExhibitionIntroSection({ exhibition, exhibitionId }: ExhibitionIntroProps) {
+	const entryTime = useRef(Date.now());
+
 	const typeLabel =
 		exhibition.exhibitionType != null
 			? (EXHIBITION_TYPE_LABEL[exhibition.exhibitionType] ?? exhibition.exhibitionType)
@@ -23,11 +29,21 @@ export function ExhibitionIntroSection({ exhibition, exhibitionId }: ExhibitionI
 	];
 
 	return (
-		<section className="flex flex-col px-4 pb-6">
+		<section className="flex flex-col px-4 pb-6" data-section="intro">
 			<Title title={exhibition.title} />
 			<RowList rows={rows} />
 			<Link href={`/${exhibitionId}/artwork`}>
-				<Button variant="main" className="w-full mt-7">
+				<Button
+					variant="main"
+					className="w-full mt-7"
+					onClick={() => {
+						const elapsedSec = Math.round((Date.now() - entryTime.current) / 1000);
+						track("Exhibition CTA Clicked", {
+							exhibition_id: exhibitionId,
+							time_to_click_sec: elapsedSec,
+						});
+					}}
+				>
 					전시물 감상하기
 				</Button>
 			</Link>

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionLocationSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionLocationSection.tsx
@@ -8,7 +8,7 @@ interface ExhibitionLocationProps {
 
 export function ExhibitionLocationSection({ location }: ExhibitionLocationProps) {
 	return (
-		<section className="flex flex-col px-4 pb-6">
+		<section className="flex flex-col px-4 pb-6" data-section="location">
 			<Title title="장소" />
 			<LocationMap address={location.address} lat={location.latitude} lng={location.longitude} />
 			<p className="text-body1">{location.address}</p>

--- a/apps/client/app/[exhibitionId]/_components/Header.tsx
+++ b/apps/client/app/[exhibitionId]/_components/Header.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Image from "next/image";
-import { useParams, useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
+import { track } from "@/lib/amplitude";
 import { useExhibition } from "../_context/ExhibitionContext";
 import { Sidebar } from "./Sidebar";
 
@@ -15,6 +16,7 @@ interface HeaderProps {
 
 export const Header = ({ variant = "logo", title }: HeaderProps) => {
 	const router = useRouter();
+	const pathname = usePathname();
 	const { slug, logoImg } = useExhibition();
 	const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
@@ -55,7 +57,11 @@ export const Header = ({ variant = "logo", title }: HeaderProps) => {
 				)}
 				<button
 					type="button"
-					onClick={() => setIsSidebarOpen((prev) => !prev)}
+					onClick={() => {
+						const next = !isSidebarOpen;
+						setIsSidebarOpen(next);
+						if (next) track("GNB Hamburger Clicked", { from_page: pathname });
+					}}
 					className="cursor-pointer"
 					aria-label={isSidebarOpen ? "메뉴 닫기" : "메뉴 열기"}
 				>

--- a/apps/client/app/[exhibitionId]/_components/Sidebar.tsx
+++ b/apps/client/app/[exhibitionId]/_components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useParams, usePathname } from "next/navigation";
 import { useEffect } from "react";
 import { Title } from "@/components/common/Title/Title";
 import { MOCK_EXHIBITION_DATA } from "@/constants/exhibition";
+import { track } from "@/lib/amplitude";
 import { MOCK_BEHIND_THE_SCENE } from "../bts/_mocks/behind-the-scene";
 
 interface SidebarProps {
@@ -65,7 +66,10 @@ export const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
 							<Link
 								key={item.label}
 								href={`${baseUrl}${item.path}`}
-								onClick={onClose}
+								onClick={() => {
+									track("GNB Nav Clicked", { label: item.label, from_page: pathname });
+									onClose();
+								}}
 								className={`py-1 cursor-pointer transition-colors ${
 									isActive(item.path) ? "text-body1-bold text-light" : "text-body1 text-lightest"
 								}`}
@@ -77,6 +81,7 @@ export const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
 
 					<Button
 						onClick={() => {
+							track("GNB Nav Clicked", { label: "dolog 홈에서 전시 보기", from_page: pathname });
 							window.open("/", "_blank", "noopener,noreferrer");
 							onClose();
 						}}

--- a/apps/client/app/[exhibitionId]/artist/[artistId]/components/Navigation/Navigator.tsx
+++ b/apps/client/app/[exhibitionId]/artist/[artistId]/components/Navigation/Navigator.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { track } from "@/lib/amplitude";
 import { navigatorStyles as s } from "./Navigator.styles";
 import type { NavItem } from "./PostNavigation/PostNavigation.types";
 
@@ -18,7 +19,17 @@ export function Navigator({ label, artistName, artistId, direction }: NavItem) {
 	const iconSrc = direction === "prev" ? "/icons/arrowUp.svg" : "/icons/arrowDown.svg";
 
 	return (
-		<Link href={href} className={s.wrapper}>
+		<Link
+			href={href}
+			className={s.wrapper}
+			onClick={() =>
+				track("Artist Navigation Clicked", {
+					direction,
+					artist_id: artistId,
+					artist_name: artistName,
+				})
+			}
+		>
 			<span className={s.left}>{artistName}</span>
 
 			<div className={s.right}>

--- a/apps/client/app/[exhibitionId]/artist/[artistId]/components/sections/ArtworkSection.tsx
+++ b/apps/client/app/[exhibitionId]/artist/[artistId]/components/sections/ArtworkSection.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { ListCardGrid } from "@/components/common/Card/ListCard/ListCardGrid";
 import { Title } from "@/components/common/Title/Title";
+import { track } from "@/lib/amplitude";
 import type { ArtistDetail } from "@/lib/api/artists/artist-detail.types";
 
 export function ArtworkSection({
@@ -9,18 +12,27 @@ export function ArtworkSection({
 	artist: ArtistDetail;
 	exhibitionId: string;
 }) {
-	return (
-		<section className="mb-6">
-			<Title title="작품" size="head2" margin="compact" />
+	const items = artist.artworks.map((a) => ({
+		id: a.artworkId,
+		title: a.title,
+		imageUrl: a.image,
+		author: artist.nameKo,
+	}));
 
+	return (
+		<section className="mb-6" data-section="artworks">
+			<Title title="작품" size="head2" margin="compact" />
 			<ListCardGrid
-				items={artist.artworks.map((a) => ({
-					id: a.artworkId,
-					title: a.title,
-					imageUrl: a.image,
-					author: artist.nameKo,
-					href: `/${exhibitionId}/artwork/${a.artworkId}`,
-				}))}
+				items={items}
+				getHref={(item) => `/${exhibitionId}/artwork/${item.id}`}
+				onItemClick={(item) =>
+					track("Artist Artwork Clicked", {
+						artwork_id: item.id,
+						artwork_title: item.title,
+						artist_name: artist.nameKo,
+						page: "artist_detail",
+					})
+				}
 			/>
 		</section>
 	);

--- a/apps/client/app/[exhibitionId]/artist/[artistId]/components/sections/ContactSection.tsx
+++ b/apps/client/app/[exhibitionId]/artist/[artistId]/components/sections/ContactSection.tsx
@@ -1,11 +1,17 @@
-import { LinkCard } from "@/components/common/Card/LinkCard/LinkCard";
-import type { LinkItem } from "@/components/common/Card/LinkCard/LinkCard.types";
+"use client";
+
+import { track } from "@/lib/amplitude";
 import type { ArtistContact } from "@/lib/api/artists/artist-detail.types";
 
-export function ContactSection({ contact }: { contact: ArtistContact }) {
-	const items: LinkItem[] = [
-		...(contact.email ? [{ label: "email", value: contact.email, type: "email" as const }] : []),
+interface ContactItem {
+	label: string;
+	value: string;
+	type: "email" | "url";
+}
 
+export function ContactSection({ contact }: { contact: ArtistContact }) {
+	const items: ContactItem[] = [
+		...(contact.email ? [{ label: "email", value: contact.email, type: "email" as const }] : []),
 		...(contact.snsList ?? []).map((s) => ({
 			label: s.platformName,
 			value: s.url,
@@ -15,5 +21,33 @@ export function ContactSection({ contact }: { contact: ArtistContact }) {
 
 	if (items.length === 0) return null;
 
-	return <LinkCard items={items} />;
+	return (
+		<div className="flex flex-col gap-1 py-4" data-section="contact">
+			{items.map((item) => (
+				<div key={item.label} className="flex flex-wrap items-center gap-1">
+					<span className="min-w-19 text-body2-bold shrink-0">{item.label}</span>
+					{item.type === "url" ? (
+						<a
+							href={item.value}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-body2 underline"
+							onClick={() =>
+								track("Artist SNS Clicked", {
+									platform: item.label,
+									page: "artist_detail",
+								})
+							}
+						>
+							{item.value}
+						</a>
+					) : (
+						<a href={`mailto:${item.value}`} className="text-body2 underline">
+							{item.value}
+						</a>
+					)}
+				</div>
+			))}
+		</div>
+	);
 }

--- a/apps/client/app/[exhibitionId]/artist/[artistId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/artist/[artistId]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Divider } from "@/components/common/Divider/Divider";
+import { SectionTimeTracker } from "@/components/common/SectionTimeTracker";
 import { resolveExhibitionSlug } from "@/lib/api/exhibition";
 import { getArtistDetail } from "../../../../lib/api/artists/artist-detail";
 import { getExhibitionMeta } from "../../_api/getExhibitionMeta";
@@ -50,10 +51,13 @@ export default async function ArtistDetailPage({ params }: Props) {
 
 	return (
 		<>
+			<SectionTimeTracker pageName="artist_detail" sections={["profile", "contact", "artworks"]} />
 			<Header variant="back" title="작가 상세" />
 
 			<div className="flex flex-col px-4 w-full mx-auto">
-				<ProfileSection artist={artist} />
+				<div data-section="profile">
+					<ProfileSection artist={artist} />
+				</div>
 
 				{(!!artist.contact.email || (artist.contact.snsList?.length ?? 0) > 0) && (
 					<ContactSection contact={artist.contact} />

--- a/apps/client/app/[exhibitionId]/artist/_components/ArtistPageClient.tsx
+++ b/apps/client/app/[exhibitionId]/artist/_components/ArtistPageClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { Divider } from "@/components/common/Divider/Divider";
 import { ScrollTabBar } from "@/components/common/ScrollTabBar/ScrollTabBar";
 import { useScrollSpy } from "@/components/common/ScrollTabBar/useScrollSpy";
+import { track } from "@/lib/amplitude";
 import type { ArtistProfile } from "@/lib/api/artists/artist";
 import type { PartnerPart } from "@/lib/api/partner";
 import { Header } from "../../_components/Header";
@@ -17,6 +18,8 @@ interface ArtistPageClientProps {
 }
 
 export function ArtistPageClient({ exhibitionId, partners, artists }: ArtistPageClientProps) {
+	const pageEntryTime = useRef(Date.now());
+
 	const TABS = useMemo(
 		() => [
 			{ id: "artists", label: "작가" },
@@ -34,7 +37,14 @@ export function ArtistPageClient({ exhibitionId, partners, artists }: ArtistPage
 		<>
 			<Header variant="logo" />
 
-			<ScrollTabBar tabs={TABS} activeTab={activeTab} onTabClick={handleTabClick} />
+			<ScrollTabBar
+				tabs={TABS}
+				activeTab={activeTab}
+				onTabClick={(tabId) => {
+					handleTabClick(tabId);
+					track("Artist Page Tab Clicked", { tab: tabId, page: "artist_list" });
+				}}
+			/>
 
 			<div className="flex flex-col w-full px-4">
 				<section
@@ -42,7 +52,19 @@ export function ArtistPageClient({ exhibitionId, partners, artists }: ArtistPage
 						sectionRefs.artists.current = el;
 					}}
 				>
-					<ArtistSection exhibitionId={exhibitionId} artists={artists} />
+					<ArtistSection
+						exhibitionId={exhibitionId}
+						artists={artists}
+						onArtistClick={(artist) => {
+							const elapsedSec = Math.round((Date.now() - pageEntryTime.current) / 1000);
+							track("Artist Card Clicked", {
+								artist_id: artist.profileId,
+								artist_name: artist.nameKo,
+								time_to_click_sec: elapsedSec,
+								page: "artist_list",
+							});
+						}}
+					/>
 				</section>
 
 				<Divider />

--- a/apps/client/app/[exhibitionId]/artist/_components/sections/ArtistSection.tsx
+++ b/apps/client/app/[exhibitionId]/artist/_components/sections/ArtistSection.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import type { CardItem } from "@/components/common/Card/Card.types";
 import { CardGrid } from "@/components/common/Card/CardGrid";
 import { EmptyArtistIcon } from "@/components/common/icons/EmptyArtistIcon";
 import { Title } from "@/components/common/Title/Title";
@@ -6,12 +9,13 @@ import type { ArtistProfile } from "@/lib/api/artists/artist";
 interface ArtistSectionProps {
 	exhibitionId: string;
 	artists: ArtistProfile[];
+	onArtistClick?: (artist: ArtistProfile) => void;
 }
 
-export function ArtistSection({ exhibitionId, artists = [] }: ArtistSectionProps) {
+export function ArtistSection({ exhibitionId, artists = [], onArtistClick }: ArtistSectionProps) {
 	if (!artists.length) return null;
 
-	const cardItems = artists.map((artist) => ({
+	const cardItems: CardItem[] = artists.map((artist) => ({
 		id: artist.profileId,
 		title: artist.nameKo || "",
 		author: artist.nameEn || "",
@@ -24,7 +28,18 @@ export function ArtistSection({ exhibitionId, artists = [] }: ArtistSectionProps
 		<section className="flex flex-col pt-4 pb-6">
 			<Title title="참여한 사람들" />
 			<Title title="작가" size="head2" margin="compact" />
-			<CardGrid items={cardItems} getHref={(item) => `/${exhibitionId}/artist/${item.id}`} />
+			<CardGrid
+				items={cardItems}
+				getHref={(item) => `/${exhibitionId}/artist/${item.id}`}
+				onItemClick={
+					onArtistClick
+						? (item) => {
+								const artist = artists.find((a) => a.profileId === item.id);
+								if (artist) onArtistClick(artist);
+							}
+						: undefined
+				}
+			/>
 		</section>
 	);
 }

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
@@ -4,7 +4,9 @@ import { useMemo } from "react";
 import { Divider } from "@/components/common/Divider/Divider";
 import { ScrollTabBar } from "@/components/common/ScrollTabBar/ScrollTabBar";
 import { useScrollSpy } from "@/components/common/ScrollTabBar/useScrollSpy";
+import { track } from "@/lib/amplitude";
 import type { ArtworkDetail } from "@/lib/api/artwork";
+import { useSectionTime } from "@/lib/hooks/useSectionTime";
 import { Header } from "../../../_components/Header";
 import { ArtistSection } from "../_components/ArtistSection";
 import { BtsSection } from "../_components/BtsSection";
@@ -17,7 +19,6 @@ import { RelatedSection } from "../_components/RelatedSection";
 import { YoutubeSection } from "../_components/YoutubeSection";
 
 export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
-	// ScrollTabBar 탭 목록 [ 작품 소개, 작가 소개, 비하인드(선택) ]
 	const TABS = useMemo(() => {
 		const base = [
 			{ id: "detail", label: "작품 소개" },
@@ -26,7 +27,11 @@ export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
 		if (data.relatedBts?.length) base.push({ id: "behind", label: "비하인드" });
 		return base;
 	}, [data.relatedBts]);
+
 	const { activeTab, handleTabClick, sectionRefs } = useScrollSpy(TABS.map((t) => t.id));
+
+	const sectionNames = useMemo(() => TABS.map((t) => t.id), [TABS]);
+	useSectionTime("artwork_detail", sectionNames);
 
 	const prevArtwork = data.alphabeticalArtworks.find((a) => a.type === "prev");
 	const nextArtwork = data.alphabeticalArtworks.find((a) => a.type === "next");
@@ -35,7 +40,6 @@ export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
 		<div className="flex flex-col">
 			<Header variant="back" />
 
-			{/* 대표 이미지 */}
 			<div className="w-full h-auto">
 				{data.mainImage ? (
 					<Image
@@ -53,24 +57,20 @@ export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
 					</div>
 				)}
 			</div>
-			{/* 작품 제목 및 정보 섹션 */}
 			<InfoSection data={data} />
-			{/* 작품 위치 섹션 */}
 			<LocationSection locationImageUrl={data.locationMap} />
-			{/* 상세 소개 섹션 */}
 			<section
+				data-section="detail"
 				ref={(el) => {
 					sectionRefs.detail.current = el;
 				}}
 			>
 				<DescriptionSection content={data.description} />
 			</section>
-			{/*  유튜브 섹션  */}
 			<YoutubeSection youtubeUrl={data.youtubeUrl} />
-			{/* 상세 이미지 섹션*/}
 			<PhotoSection data={data} />
-			{/* 참여자 섹션 */}
 			<section
+				data-section="artist"
 				ref={(el) => {
 					sectionRefs.artist.current = el;
 				}}
@@ -78,11 +78,11 @@ export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
 				<ArtistSection authors={data.participants} />
 			</section>
 
-			{/* BTS 섹션 - 선택값 */}
 			{data.relatedBts && data.relatedBts.length > 0 && (
 				<>
 					<Divider />
 					<section
+						data-section="behind"
 						ref={(el) => {
 							sectionRefs.behind.current = el;
 						}}
@@ -91,15 +91,19 @@ export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
 					</section>
 				</>
 			)}
-			{/* 동일한 카테고리 작품 섹션 */}
 			{data.sameCategoryArtworks && data.sameCategoryArtworks.length > 0 && (
-				<RelatedSection artworks={data.sameCategoryArtworks} />
+				<RelatedSection artworks={data.sameCategoryArtworks} artworkTitle={data.title} />
 			)}
-			{/* 둘러보기 섹션 */}
 			<PostNavigationSection prevArtwork={prevArtwork} nextArtwork={nextArtwork} />
 
-			{/* 하단 스크롤탭바 */}
-			<ScrollTabBar tabs={TABS} activeTab={activeTab} onTabClick={handleTabClick} />
+			<ScrollTabBar
+				tabs={TABS}
+				activeTab={activeTab}
+				onTabClick={(tabId) => {
+					handleTabClick(tabId);
+					track("Artwork Tab Clicked", { tab: tabId, artwork_title: data.title });
+				}}
+			/>
 		</div>
 	);
 }

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/PostNavigationSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/PostNavigationSection.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
+import { track } from "@/lib/amplitude";
 import type { RelatedArtwork } from "@/lib/api/artwork";
 
 interface PostNavigationProps {
@@ -14,7 +17,16 @@ export function PostNavigationSection({ prevArtwork, nextArtwork }: PostNavigati
 			<hr className="border border-stroke-lighter" />
 
 			{prevArtwork && (
-				<Link href={`../artwork/${prevArtwork.id}`}>
+				<Link
+					href={`../artwork/${prevArtwork.id}`}
+					onClick={() =>
+						track("Artwork Navigation Clicked", {
+							direction: "prev",
+							artwork_id: prevArtwork.id,
+							artwork_title: prevArtwork.title,
+						})
+					}
+				>
 					<div className="flex items-center justify-between py-2.5 gap-4">
 						<div className="flex items-center gap-2 flex-1 min-w-0">
 							{prevArtwork.mainImage ? (
@@ -51,7 +63,16 @@ export function PostNavigationSection({ prevArtwork, nextArtwork }: PostNavigati
 			<hr className="border border-stroke-lightest" />
 
 			{nextArtwork && (
-				<Link href={`../artwork/${nextArtwork.id}`}>
+				<Link
+					href={`../artwork/${nextArtwork.id}`}
+					onClick={() =>
+						track("Artwork Navigation Clicked", {
+							direction: "next",
+							artwork_id: nextArtwork.id,
+							artwork_title: nextArtwork.title,
+						})
+					}
+				>
 					<div className="flex items-center justify-between py-2.5 gap-4">
 						<div className="flex items-center gap-2 flex-1 min-w-0">
 							{nextArtwork.mainImage ? (

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/RelatedSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/RelatedSection.tsx
@@ -1,13 +1,16 @@
+"use client";
+
 import { CardGrid } from "@/components/common/Card/CardGrid";
 import { Title } from "@/components/common/Title/Title";
+import { track } from "@/lib/amplitude";
 import type { RelatedArtwork } from "@/lib/api/artwork";
 
 interface RelatedSectionProps {
 	artworks: RelatedArtwork[];
+	artworkTitle?: string;
 }
 
-export const RelatedSection = ({ artworks }: RelatedSectionProps) => {
-	// 직접 카테고리 filter 대신 백에서 내려주는 데이터로 받음
+export const RelatedSection = ({ artworks, artworkTitle }: RelatedSectionProps) => {
 	const items = artworks.map((a) => ({
 		id: a.id,
 		title: a.title,
@@ -19,7 +22,19 @@ export const RelatedSection = ({ artworks }: RelatedSectionProps) => {
 	return (
 		<section className="flex flex-col px-4 pb-6">
 			<Title title="동일한 카테고리 작품" margin="compact" />
-			<CardGrid items={items} getHref={(item) => `${item.id}`} limit={2} />
+			<CardGrid
+				items={items}
+				getHref={(item) => `${item.id}`}
+				limit={2}
+				onItemClick={(item) =>
+					track("Related Artwork Clicked", {
+						clicked_artwork_id: item.id,
+						clicked_artwork_title: item.title,
+						from_artwork: artworkTitle,
+						page: "artwork_detail",
+					})
+				}
+			/>
 		</section>
 	);
 };

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/components/ArtistCard.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/components/ArtistCard.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import { Button } from "components";
 import Image from "next/image";
 import Link from "next/link";
 import { EmptyArtistIcon } from "@/components/common/icons/EmptyArtistIcon";
 import RowList from "@/components/common/RowList/RowList";
+import { track } from "@/lib/amplitude";
 import type { ArtworkParticipant } from "@/lib/api/artwork";
 
 export interface ArtistCardProps {
@@ -11,10 +14,8 @@ export interface ArtistCardProps {
 }
 
 export function ArtistCard({ author, profileHref }: ArtistCardProps) {
-	// artist → author
 	return (
 		<div className="flex flex-col">
-			{/* 프로필 이미지 + 이름 */}
 			<div className="flex">
 				<div className="relative shrink-0 w-32 aspect-[1/1.414]">
 					{author.profileImg ? (
@@ -35,10 +36,8 @@ export function ArtistCard({ author, profileHref }: ArtistCardProps) {
 				</div>
 			</div>
 
-			{/* 소개글 */}
 			{author.bio && <p className="text-body1 pt-4 pb-6">{author.bio}</p>}
 
-			{/* 연락처 - 선택값 */}
 			{(!!author.email || (author.sns ?? []).length > 0) && (
 				<div className="flex flex-col pb-5 pt-6">
 					<RowList
@@ -78,9 +77,19 @@ export function ArtistCard({ author, profileHref }: ArtistCardProps) {
 					/>
 				</div>
 			)}
-			{/* 프로필 더보기 버튼 */}
 			<Link href={profileHref}>
-				<Button variant="outline" size="sm" className="w-full">
+				<Button
+					variant="outline"
+					size="sm"
+					className="w-full"
+					onClick={() =>
+						track("Profile More Clicked", {
+							artist_id: author.profileId,
+							artist_name: author.nameKo,
+							page: "artwork_detail",
+						})
+					}
+				>
 					프로필 더보기
 				</Button>
 			</Link>

--- a/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
@@ -6,6 +6,7 @@ import { ListCardGrid } from "@/components/common/Card/ListCard/ListCardGrid";
 import { EmptyState } from "@/components/common/EmptyState/EmptyState";
 import { SearchBar } from "@/components/common/SearchBar/SearchBar";
 import { Title } from "@/components/common/Title/Title";
+import { track } from "@/lib/amplitude";
 import type { ArtworkListItem } from "@/lib/api/artwork";
 import { useIntersectionObserver } from "../hooks/useIntersectionObserver";
 import { AlbumIcon } from "./components/AlbumIcon";
@@ -23,17 +24,12 @@ interface ArtworkListSectionProps {
 	zones: FilteredZone[];
 	searchQuery: string;
 	onSearchChange: (value: string) => void;
-	/* useArtworkFilter 중복 호출을 제거하고 props로 받고자 함 */
 	categories: string[];
 	selected: string;
 	onSelect: (value: string) => void;
 	hideFilter?: boolean;
 }
 
-// [임시] Artwork → CardItem 변환
-// 현재 백엔드 스펙에 맞춰 Artwork 타입으로 목데이터를 구성했습니다.
-// Card 컴포넌트들이 현재 CardItem 타입을 받고 있고 여러 곳에서 쓰이고 있어 임시로 변환했습니다.
-// 추후 백엔드 연동 시 Card 컴포넌트 타입을 Artwork 기준으로 수정하면 이 변환 로직은 제거할 예정입니다!
 const toCardItem = (artwork: ArtworkListItem): CardItem => ({
 	id: artwork.id,
 	imageUrl: artwork.imageUrl,
@@ -41,7 +37,6 @@ const toCardItem = (artwork: ArtworkListItem): CardItem => ({
 	author: artwork.artistName || "",
 });
 
-// 보기 방식 토글 버튼
 const ViewToggle = ({
 	viewMode,
 	setViewMode,
@@ -52,13 +47,19 @@ const ViewToggle = ({
 	<div className="flex gap-1 p-1 h-8 rounded-2 border border-stroke-lightest shrink-0">
 		<ListIcon
 			active={viewMode === "list"}
-			onClick={() => setViewMode("list")}
+			onClick={() => {
+				setViewMode("list");
+				track("View Mode Changed", { mode: "list", page: "artwork_list" });
+			}}
 			className="cursor-pointer"
 		/>
 		<div className="w-px h-full border border-stroke-lighter pointer-events-none" />
 		<AlbumIcon
 			active={viewMode === "grid"}
-			onClick={() => setViewMode("grid")}
+			onClick={() => {
+				setViewMode("grid");
+				track("View Mode Changed", { mode: "grid", page: "artwork_list" });
+			}}
 			className="cursor-pointer"
 		/>
 	</div>
@@ -80,13 +81,11 @@ export function ArtworkListSection({
 
 	return (
 		<section className="flex flex-col">
-			{/* 스크롤 전 (Title + 토글버튼) */}
 			<div ref={titleRef} className="flex justify-between items-center px-4">
 				<Title title="작품 목록" />
 				<ViewToggle viewMode={viewMode} setViewMode={setViewMode} />
 			</div>
 
-			{/* sticky 영역 */}
 			<div className="sticky top-11 bg-normal z-10 px-4 pb-2">
 				<SearchBar
 					placeholder="작품명, 작가명을 검색하세요"
@@ -96,7 +95,14 @@ export function ArtworkListSection({
 				/>
 				<div className="flex items-center">
 					{!hideFilter && (
-						<Filter categories={categories} selected={selected} onSelect={onSelect} />
+						<Filter
+							categories={categories}
+							selected={selected}
+							onSelect={(val) => {
+								onSelect(val);
+								track("Category Filter Selected", { category: val, page: "artwork_list" });
+							}}
+						/>
 					)}
 					{!isTitleVisible && (
 						<div className="ml-auto">
@@ -106,11 +112,6 @@ export function ArtworkListSection({
 				</div>
 			</div>
 
-			{/* 작품 목록 */}
-			{/* 
-			구역이 1개일 경우 작품 목록만
-			구역이 2개 이상일 경우 구역 Title과 함께 작품 목록을
-			렌더링 합니다 */}
 			<div className="flex flex-col px-4 gap-6">
 				{zones.map((zone) => {
 					const items = zone.artworks.map(toCardItem);
@@ -134,9 +135,31 @@ export function ArtworkListSection({
 									className="w-full pb-16 pt-10 px-2.5"
 								/>
 							) : viewMode === "grid" ? (
-								<CardGrid items={items} getHref={(item) => `artwork/${item.id}`} />
+								<CardGrid
+									items={items}
+									getHref={(item) => `artwork/${item.id}`}
+									onItemClick={(item) =>
+										track("Artwork Card Clicked", {
+											artwork_id: item.id,
+											artwork_title: item.title,
+											zone: zone.zoneName,
+											page: "artwork_list",
+										})
+									}
+								/>
 							) : (
-								<ListCardGrid items={items} getHref={(item) => `artwork/${item.id}`} />
+								<ListCardGrid
+									items={items}
+									getHref={(item) => `artwork/${item.id}`}
+									onItemClick={(item) =>
+										track("Artwork Card Clicked", {
+											artwork_id: item.id,
+											artwork_title: item.title,
+											zone: zone.zoneName,
+											page: "artwork_list",
+										})
+									}
+								/>
 							)}
 						</div>
 					);

--- a/apps/client/app/[exhibitionId]/artwork/_components/ArtworksClient.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/_components/ArtworksClient.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { ScrollTabBar } from "@/components/common/ScrollTabBar/ScrollTabBar";
 import { useScrollSpy } from "@/components/common/ScrollTabBar/useScrollSpy";
+import { track } from "@/lib/amplitude";
 import type { ExhibitionMap, ZoneGroup } from "@/lib/api/artwork";
 import { useArtworkFilter } from "../hooks/useArtworkFilter";
 import { ArtworkListSection } from "./ArtworkListSection";
@@ -53,7 +54,14 @@ export function ArtworksClient({ maps, zones, hideFilter }: ArtworksClientProps)
 				onSelect={setSelected}
 				hideFilter={hideFilter}
 			/>
-			<ScrollTabBar tabs={TABS} activeTab={activeTab} onTabClick={handleTabClick} />
+			<ScrollTabBar
+				tabs={TABS}
+				activeTab={activeTab}
+				onTabClick={(tabId) => {
+					handleTabClick(tabId);
+					track("Zone Tab Clicked", { zone: tabId, page: "artwork_list" });
+				}}
+			/>
 		</>
 	);
 }

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ExhibitionPageTracker } from "@/components/common/ExhibitionPageTracker";
 import MainFooter from "@/components/common/Footer/MainFooter";
 import SchoolFooter from "@/components/common/Footer/SchoolFooter";
 import { getExhibitions } from "@/lib/api/exhibition";
@@ -83,6 +84,7 @@ export default async function ExhibitionLayout({
 				}}
 			>
 				<div className="bg-normal text-strong min-h-dvh flex flex-col" style={colorVars}>
+					<ExhibitionPageTracker />
 					<div className="min-h-dvh flex flex-col w-full max-w-135 mx-auto">{children}</div>
 
 					{footer ? (

--- a/apps/client/app/[exhibitionId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { Divider } from "@/components/common/Divider/Divider";
+import { SectionTimeTracker } from "@/components/common/SectionTimeTracker";
 import { getExhibitionDetail, getExhibitionHost, getHostSns } from "@/lib/api/exhibition";
 import { resolveExhibitionId } from "./_api/resolveExhibitionId";
 import { ExhibitionDetailSection } from "./_components/ExhibitionDetailSection";
@@ -34,6 +35,10 @@ export default async function ExhibitionDetailPage({ params }: ExhibitionDetailP
 
 	return (
 		<main>
+			<SectionTimeTracker
+				pageName="exhibition_intro"
+				sections={["intro", "detail", "location", "host"]}
+			/>
 			<Header />
 			{/* 대표 이미지 */}
 			<div className="relative w-full aspect-[1/1.414]">

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import { AmplitudeProvider } from "@/providers/amplitude-provider";
 
 export const metadata: Metadata = {
 	title: "두록",
@@ -18,17 +19,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 	return (
 		<html lang="ko" suppressHydrationWarning>
 			<body className="flex justify-center">
-				<main
-					className="
-					w-full max-w-135
-					min-h-dvh 
-					shadow-xl 
-					relative 
-					flex flex-col
-					"
-				>
-					{children}
-				</main>
+				<AmplitudeProvider>
+					<main
+						className="
+						w-full max-w-135
+						min-h-dvh
+						shadow-xl
+						relative
+						flex flex-col
+						"
+					>
+						{children}
+					</main>
+				</AmplitudeProvider>
 			</body>
 		</html>
 	);

--- a/apps/client/components/common/Card/Card.tsx
+++ b/apps/client/components/common/Card/Card.tsx
@@ -10,7 +10,8 @@ export const Card = ({
 	author,
 	href,
 	emptyIcon,
-}: CardProps & { href?: string }) => {
+	onClick,
+}: CardProps & { href?: string; onClick?: () => void }) => {
 	const content = (
 		<article className={s.wrapper}>
 			<div className={s.imageWrapper}>
@@ -47,5 +48,11 @@ export const Card = ({
 		</article>
 	);
 
-	return href ? <Link href={href}>{content}</Link> : content;
+	return href ? (
+		<Link href={href} onClick={onClick}>
+			{content}
+		</Link>
+	) : (
+		content
+	);
 };

--- a/apps/client/components/common/Card/Card.types.ts
+++ b/apps/client/components/common/Card/Card.types.ts
@@ -19,5 +19,6 @@ export interface CardGridProps {
 	items: CardItem[];
 	limit?: number;
 	getHref?: (item: CardItem) => string;
+	onItemClick?: (item: CardItem) => void;
 	className?: string;
 }

--- a/apps/client/components/common/Card/CardGrid.tsx
+++ b/apps/client/components/common/Card/CardGrid.tsx
@@ -1,13 +1,18 @@
 import { Card } from "./Card";
 import type { CardGridProps } from "./Card.types";
 
-export const CardGrid = ({ items, limit, getHref }: CardGridProps) => {
+export const CardGrid = ({ items, limit, getHref, onItemClick, className }: CardGridProps) => {
 	const displayedItems = limit ? items.slice(0, limit) : items;
 
 	return (
-		<div className="grid grid-cols-2 gap-x-4 gap-y-6 w-full">
+		<div className={`grid grid-cols-2 gap-x-4 gap-y-6 w-full ${className ?? ""}`}>
 			{displayedItems.map((item) => (
-				<Card key={item.id} {...item} href={getHref?.(item)} />
+				<Card
+					key={item.id}
+					{...item}
+					href={getHref?.(item)}
+					onClick={onItemClick ? () => onItemClick(item) : undefined}
+				/>
 			))}
 		</div>
 	);

--- a/apps/client/components/common/Card/ListCard/ListCardGrid.tsx
+++ b/apps/client/components/common/Card/ListCard/ListCardGrid.tsx
@@ -2,14 +2,18 @@ import Link from "next/link";
 import type { CardGridProps } from "../Card.types";
 import { ListCard } from "./ListCard";
 
-export const ListCardGrid = ({ items, limit, getHref, className }: CardGridProps) => {
+export const ListCardGrid = ({ items, limit, getHref, onItemClick, className }: CardGridProps) => {
 	const displayedItems = limit ? items.slice(0, limit) : items;
 
 	return (
 		<div className={`flex flex-col gap-y-6 w-full ${className ?? ""}`}>
 			{displayedItems.map((item) =>
 				getHref ? (
-					<Link key={item.id} href={getHref(item)}>
+					<Link
+						key={item.id}
+						href={getHref(item)}
+						onClick={onItemClick ? () => onItemClick(item) : undefined}
+					>
 						<ListCard {...item} />
 					</Link>
 				) : (

--- a/apps/client/components/common/ExhibitionPageTracker.tsx
+++ b/apps/client/components/common/ExhibitionPageTracker.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useDwellTime } from "@/lib/hooks/useDwellTime";
+import { useScrollDepth } from "@/lib/hooks/useScrollDepth";
+
+function resolvePageName(pathname: string): string {
+	// /:exhibitionId/artwork/:artworkId
+	if (/\/artwork\/[^/]+$/.test(pathname)) return "artwork_detail";
+	// /:exhibitionId/artwork
+	if (/\/artwork$/.test(pathname)) return "artwork_list";
+	// /:exhibitionId/artist/:artistId
+	if (/\/artist\/[^/]+$/.test(pathname)) return "artist_detail";
+	// /:exhibitionId/artist
+	if (/\/artist$/.test(pathname)) return "artist_list";
+	// /:exhibitionId/bts/:btsId
+	if (/\/bts\/[^/]+$/.test(pathname)) return "bts_detail";
+	// /:exhibitionId/bts
+	if (/\/bts$/.test(pathname)) return "bts_list";
+	// /:exhibitionId (exhibition intro)
+	return "exhibition_intro";
+}
+
+export function ExhibitionPageTracker() {
+	const pathname = usePathname();
+	const pageName = resolvePageName(pathname);
+
+	useDwellTime(pageName);
+	useScrollDepth(pageName);
+
+	return null;
+}

--- a/apps/client/components/common/PageTracker.tsx
+++ b/apps/client/components/common/PageTracker.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useDwellTime } from "@/lib/hooks/useDwellTime";
+import { useScrollDepth } from "@/lib/hooks/useScrollDepth";
+
+interface Props {
+	pageName: string;
+}
+
+export function PageTracker({ pageName }: Props) {
+	useDwellTime(pageName);
+	useScrollDepth(pageName);
+	return null;
+}

--- a/apps/client/components/common/SectionTimeTracker.tsx
+++ b/apps/client/components/common/SectionTimeTracker.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useSectionTime } from "@/lib/hooks/useSectionTime";
+
+interface Props {
+	pageName: string;
+	sections: string[];
+}
+
+export function SectionTimeTracker({ pageName, sections }: Props) {
+	useSectionTime(pageName, sections);
+	return null;
+}

--- a/apps/client/components/common/TrackedLink.tsx
+++ b/apps/client/components/common/TrackedLink.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { track } from "@/lib/amplitude";
+
+interface Props {
+	href: string;
+	eventName: string;
+	eventProps?: Record<string, unknown>;
+	className?: string;
+	children: React.ReactNode;
+	target?: string;
+	rel?: string;
+}
+
+export function TrackedLink({
+	href,
+	eventName,
+	eventProps,
+	className,
+	children,
+	target,
+	rel,
+}: Props) {
+	return (
+		<Link
+			href={href}
+			className={className}
+			target={target}
+			rel={rel}
+			onClick={() => track(eventName, eventProps)}
+		>
+			{children}
+		</Link>
+	);
+}

--- a/apps/client/lib/amplitude.ts
+++ b/apps/client/lib/amplitude.ts
@@ -1,0 +1,17 @@
+import * as amplitude from "@amplitude/analytics-browser";
+
+export const initAmplitude = () => {
+	amplitude.init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY ?? "", {
+		autocapture: {
+			pageViews: true, // 페이지뷰 + referrer + UTM 자동 수집
+			sessions: true,
+			elementInteractions: false,
+		},
+	});
+};
+
+export const track = (eventName: string, properties?: Record<string, unknown>) => {
+	amplitude.track(eventName, properties);
+};
+
+export { amplitude };

--- a/apps/client/lib/hooks/useDwellTime.ts
+++ b/apps/client/lib/hooks/useDwellTime.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { track } from "@/lib/amplitude";
+
+const INACTIVITY_MS = 60_000;
+const MAX_DWELL_MS = 15 * 60_000;
+
+export function useDwellTime(pageName: string) {
+	const state = useRef({
+		activeMs: 0,
+		lastActive: 0,
+		inactive: false,
+		flushed: false,
+		inactivityTimer: null as ReturnType<typeof setTimeout> | null,
+		maxTimer: null as ReturnType<typeof setTimeout> | null,
+	});
+
+	useEffect(() => {
+		const s = state.current;
+		s.activeMs = 0;
+		s.lastActive = Date.now();
+		s.inactive = false;
+		s.flushed = false;
+
+		const flush = () => {
+			if (s.flushed) return;
+			s.flushed = true;
+			if (!s.inactive) s.activeMs += Date.now() - s.lastActive;
+			const duration = Math.min(s.activeMs, MAX_DWELL_MS);
+			track("Page Dwell Time", {
+				page: pageName,
+				duration_ms: duration,
+				duration_sec: Math.round(duration / 1000),
+			});
+		};
+
+		const onActivity = () => {
+			const now = Date.now();
+			if (s.inactive) {
+				s.inactive = false;
+				s.lastActive = now;
+			}
+			if (s.inactivityTimer) clearTimeout(s.inactivityTimer);
+			s.inactivityTimer = setTimeout(() => {
+				s.activeMs += Date.now() - s.lastActive;
+				s.inactive = true;
+			}, INACTIVITY_MS);
+		};
+
+		const events = ["scroll", "click", "touchstart", "keydown"] as const;
+		for (const ev of events) window.addEventListener(ev, onActivity, { passive: true });
+
+		s.maxTimer = setTimeout(flush, MAX_DWELL_MS);
+
+		return () => {
+			for (const ev of events) window.removeEventListener(ev, onActivity);
+			if (s.inactivityTimer) clearTimeout(s.inactivityTimer);
+			if (s.maxTimer) clearTimeout(s.maxTimer);
+			flush();
+		};
+	}, [pageName]);
+}

--- a/apps/client/lib/hooks/useScrollDepth.ts
+++ b/apps/client/lib/hooks/useScrollDepth.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { track } from "@/lib/amplitude";
+
+const THRESHOLDS = [25, 50, 75, 100] as const;
+
+export function useScrollDepth(pageName: string) {
+	const reached = useRef(new Set<number>());
+
+	useEffect(() => {
+		reached.current.clear();
+
+		const onScroll = () => {
+			const el = document.documentElement;
+			const scrolled = el.scrollTop + el.clientHeight;
+			const total = el.scrollHeight;
+			if (total <= el.clientHeight) return;
+
+			const pct = (scrolled / total) * 100;
+
+			for (const threshold of THRESHOLDS) {
+				if (pct >= threshold && !reached.current.has(threshold)) {
+					reached.current.add(threshold);
+					track("Scroll Depth Reached", { page: pageName, depth_percent: threshold });
+				}
+			}
+		};
+
+		window.addEventListener("scroll", onScroll, { passive: true });
+		return () => window.removeEventListener("scroll", onScroll);
+	}, [pageName]);
+}

--- a/apps/client/lib/hooks/useSectionTime.ts
+++ b/apps/client/lib/hooks/useSectionTime.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import { track } from "@/lib/amplitude";
+
+// 섹션에 data-section="name" 속성을 부여하면 자동으로 체류 시간을 측정합니다
+export function useSectionTime(pageName: string, sectionNames: string[]) {
+	useEffect(() => {
+		const timers: Record<string, { start: number; total: number }> = {};
+		for (const name of sectionNames) timers[name] = { start: 0, total: 0 };
+
+		const observers: IntersectionObserver[] = [];
+
+		for (const name of sectionNames) {
+			const el = document.querySelector(`[data-section="${name}"]`);
+			if (!el) continue;
+
+			const observer = new IntersectionObserver(
+				([entry]) => {
+					if (entry.isIntersecting) {
+						timers[name].start = Date.now();
+					} else if (timers[name].start > 0) {
+						timers[name].total += Date.now() - timers[name].start;
+						timers[name].start = 0;
+					}
+				},
+				{ threshold: 0.3 },
+			);
+
+			observer.observe(el);
+			observers.push(observer);
+		}
+
+		return () => {
+			const results: Record<string, number> = {};
+			for (const [name, t] of Object.entries(timers)) {
+				let total = t.total;
+				if (t.start > 0) total += Date.now() - t.start;
+				results[name] = Math.round(total / 1000);
+			}
+
+			const sorted = Object.entries(results).sort((a, b) => b[1] - a[1]);
+			if (sorted.length && sorted[0][1] > 0) {
+				track("Most Visited Section", {
+					page: pageName,
+					top_section: sorted[0][0],
+					section_times_sec: results,
+				});
+			}
+
+			for (const ob of observers) ob.disconnect();
+		};
+	}, [pageName, sectionNames]);
+}

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -10,11 +10,11 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.42.3",
     "@radix-ui/react-dialog": "^1.1.15",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "api": "workspace:*",
     "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "components": "workspace:*",
     "next": "16.1.6",
     "next-themes": "^0.4.6",

--- a/apps/client/providers/amplitude-provider.tsx
+++ b/apps/client/providers/amplitude-provider.tsx
@@ -37,7 +37,10 @@ export function AmplitudeProvider({ children }: { children: React.ReactNode }) {
 	useEffect(() => {
 		initAmplitude();
 
-		// 유저 속성 (재방문 판별)
+		/**
+		 * 유저 데이터 | 재방문율 계산을 위함
+		 * : device_id 기반 재방문 유저 트래킹 구현
+		 */
 		const now = new Date().toISOString();
 		const raw = localStorage.getItem(VISIT_KEY);
 		const store: VisitStore = raw ? JSON.parse(raw) : { count: 0, first: now };
@@ -53,7 +56,9 @@ export function AmplitudeProvider({ children }: { children: React.ReactNode }) {
 		identify.set("last_visit_date", now);
 		amplitude.identify(identify);
 
-		// 유입 경로 분류
+		/**
+		 * 유입 경로 트래킹
+		 */
 		const referrer = document.referrer;
 		const search = window.location.search;
 		const params = new URLSearchParams(search);
@@ -61,13 +66,13 @@ export function AmplitudeProvider({ children }: { children: React.ReactNode }) {
 
 		track("Platform Entry", {
 			traffic_source: trafficSource,
-			utm_source: params.get("utm_source") ?? "",
-			utm_medium: params.get("utm_medium") ?? "",
-			utm_campaign: params.get("utm_campaign") ?? "",
-			utm_term: params.get("utm_term") ?? "",
-			referrer_url: referrer || "direct",
-			landing_page: window.location.href,
-			entry_time: now,
+			utm_source: params.get("utm_source") ?? "", // 유입 소스
+			utm_medium: params.get("utm_medium") ?? "", // 유입 매체
+			utm_campaign: params.get("utm_campaign") ?? "", // 캠페인명
+			utm_term: params.get("utm_term") ?? "", // 검색 키워드
+			referrer_url: referrer || "direct", 
+			landing_page: window.location.href, // 랜딩 페이지 URL
+			entry_time: now, // 유입 시각
 			is_new_user: isNew,
 		});
 	}, []);

--- a/apps/client/providers/amplitude-provider.tsx
+++ b/apps/client/providers/amplitude-provider.tsx
@@ -70,7 +70,7 @@ export function AmplitudeProvider({ children }: { children: React.ReactNode }) {
 			utm_medium: params.get("utm_medium") ?? "", // 유입 매체
 			utm_campaign: params.get("utm_campaign") ?? "", // 캠페인명
 			utm_term: params.get("utm_term") ?? "", // 검색 키워드
-			referrer_url: referrer || "direct", 
+			referrer_url: referrer || "direct",
 			landing_page: window.location.href, // 랜딩 페이지 URL
 			entry_time: now, // 유입 시각
 			is_new_user: isNew,

--- a/apps/client/providers/amplitude-provider.tsx
+++ b/apps/client/providers/amplitude-provider.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Identify } from "@amplitude/analytics-browser";
+import { useEffect } from "react";
+import { amplitude, initAmplitude, track } from "@/lib/amplitude";
+
+const VISIT_KEY = "dolog_v";
+
+interface VisitStore {
+	count: number;
+	first: string;
+}
+
+function classifyTrafficSource(referrer: string, search: string): string {
+	const params = new URLSearchParams(search);
+	const utmSource = params.get("utm_source")?.toLowerCase() ?? "";
+	const utmMedium = params.get("utm_medium")?.toLowerCase() ?? "";
+
+	if (utmSource.includes("kakao") || utmMedium.includes("kakao")) return "Kakao";
+
+	const socialDomains = ["instagram", "facebook", "twitter", "tiktok", "youtube", "linkedin"];
+	if (socialDomains.some((d) => utmSource.includes(d) || referrer.includes(d))) return "Social";
+
+	if (utmMedium === "cpc" || utmMedium === "paid") return "Paid Search";
+
+	const searchEngines = ["google", "naver", "daum", "bing", "yahoo"];
+	if (searchEngines.some((e) => referrer.includes(e))) return "Organic Search";
+
+	if (referrer && !referrer.includes(window.location.hostname)) return "Referral";
+
+	if (!referrer) return "Direct";
+
+	return "Unknown";
+}
+
+export function AmplitudeProvider({ children }: { children: React.ReactNode }) {
+	useEffect(() => {
+		initAmplitude();
+
+		// 유저 속성 (재방문 판별)
+		const now = new Date().toISOString();
+		const raw = localStorage.getItem(VISIT_KEY);
+		const store: VisitStore = raw ? JSON.parse(raw) : { count: 0, first: now };
+		store.count += 1;
+		localStorage.setItem(VISIT_KEY, JSON.stringify(store));
+
+		const isNew = store.count === 1;
+		const identify = new Identify();
+		identify.setOnce("first_visit_date", store.first);
+		identify.set("is_new_user", isNew);
+		identify.set("user_type", isNew ? "new" : "returning");
+		identify.set("visit_count", store.count);
+		identify.set("last_visit_date", now);
+		amplitude.identify(identify);
+
+		// 유입 경로 분류
+		const referrer = document.referrer;
+		const search = window.location.search;
+		const params = new URLSearchParams(search);
+		const trafficSource = classifyTrafficSource(referrer, search);
+
+		track("Platform Entry", {
+			traffic_source: trafficSource,
+			utm_source: params.get("utm_source") ?? "",
+			utm_medium: params.get("utm_medium") ?? "",
+			utm_campaign: params.get("utm_campaign") ?? "",
+			utm_term: params.get("utm_term") ?? "",
+			referrer_url: referrer || "direct",
+			landing_page: window.location.href,
+			entry_time: now,
+			is_new_user: isNew,
+		});
+	}, []);
+
+	return <>{children}</>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.1
@@ -67,6 +67,9 @@ importers:
 
   apps/client:
     dependencies:
+      '@amplitude/analytics-browser':
+        specifier: ^2.42.3
+        version: 2.42.3
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -118,7 +121,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.1
@@ -161,6 +164,39 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@amplitude/analytics-browser@2.42.3':
+    resolution: {integrity: sha512-zej80Yb7G56xjNeURhyFDXgluIroIdcCQVg6bcTQebJOp2HkjleUL7YMa/891sdmKuqJ8TrZgJoCE7wMz2fqcg==}
+
+  '@amplitude/analytics-connector@1.6.4':
+    resolution: {integrity: sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==}
+
+  '@amplitude/analytics-core@2.48.0':
+    resolution: {integrity: sha512-6ckWWL60LiJJEQQ5V3Veviq0Gl5Lcvy1dFaRDKA/SwLT3cgiBrEFZXZPcri4wDGjchPmJXFCYcE55nr7rP6Wjg==}
+
+  '@amplitude/analytics-core@2.48.1':
+    resolution: {integrity: sha512-6ltecomnZc9z1AUE59orcoLYii0gPoVBBoI4qoMGXw2lsxFh35zx32LPrXO3ezFkTE71CS44AzwaBFsSxQWRuw==}
+
+  '@amplitude/plugin-autocapture-browser@1.27.1':
+    resolution: {integrity: sha512-vJxwfExfREBIMbVydAimO/diYsRfNBD/nqo+DABURBsdmb+gliUPd7J6g22ys7al59+ixRwJSQMUrk0bnqn76Q==}
+
+  '@amplitude/plugin-custom-enrichment-browser@0.1.8':
+    resolution: {integrity: sha512-PVg56GfQID/UKLZx7imbg6Tmlj2AX/euyG7nnouKpowgGJ7jz/t4o2u3csSgrKbLSrTjxdbXVdPyz/+CecJ4Zg==}
+
+  '@amplitude/plugin-event-property-attribution-browser@0.2.0':
+    resolution: {integrity: sha512-7GmAvpOf7CbdIL++9PrdNB8GeyUvL5/yRrv1hnVC7rv19MKumbYK9Oq1utOUr6nddPfQU3w3sz9YK5A8cUVrlQ==}
+
+  '@amplitude/plugin-network-capture-browser@1.10.0':
+    resolution: {integrity: sha512-wDTxpeDCst+pKyfRnVH1RYV93ctQtfuAQuCaUHqSO/TYcHnidGFWLl/UVbMvJ6EkrPoDXOCCTk5gTSPVMKSp0w==}
+
+  '@amplitude/plugin-page-url-enrichment-browser@0.7.10':
+    resolution: {integrity: sha512-ILehefdpqUk1iK4G8kTlRxmf7OogiG2Y4lRph2cvsw25a9zVUpPXeZ5H4us9uEWrsUI0Y7w6FJlt3MMBJRMiBA==}
+
+  '@amplitude/plugin-page-view-tracking-browser@2.11.0':
+    resolution: {integrity: sha512-ZI/1kTQID0yXileGjvseMoFZ9zUbLG5r+MsznmT0Br+x91LdCrPHXdpU7lq53UAwIhgREXk9S/o/AwUZfFSgzg==}
+
+  '@amplitude/plugin-web-vitals-browser@1.1.32':
+    resolution: {integrity: sha512-cf/MR5WTJ5iwCjxdy9f7vK8zy2nD1iXPwu8eKHiRxWR7Eoqx7bT30n9dar8kWDV8kraV0sglA5pVrP3b33m/pw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -886,6 +922,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/zen-observable@0.8.3':
+    resolution: {integrity: sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==}
 
   '@typescript-eslint/eslint-plugin@8.57.0':
     resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
@@ -2165,6 +2204,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-json-stringify@1.2.0:
+    resolution: {integrity: sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -2423,6 +2465,9 @@ packages:
       '@types/react':
         optional: true
 
+  web-vitals@5.1.0:
+    resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2455,6 +2500,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zen-observable@0.10.0:
+    resolution: {integrity: sha512-iI3lT0iojZhKwT5DaFy2Ce42n3yFcLdFyOh01G7H0flMY60P8MJuVFEoJoNwXlmAyQ45GrjL6AcZmmlv8A5rbw==}
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
@@ -2467,6 +2515,72 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@amplitude/analytics-browser@2.42.3':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.1
+      '@amplitude/plugin-autocapture-browser': 1.27.1
+      '@amplitude/plugin-custom-enrichment-browser': 0.1.8
+      '@amplitude/plugin-event-property-attribution-browser': 0.2.0
+      '@amplitude/plugin-network-capture-browser': 1.10.0
+      '@amplitude/plugin-page-url-enrichment-browser': 0.7.10
+      '@amplitude/plugin-page-view-tracking-browser': 2.11.0
+      '@amplitude/plugin-web-vitals-browser': 1.1.32
+      tslib: 2.8.1
+
+  '@amplitude/analytics-connector@1.6.4': {}
+
+  '@amplitude/analytics-core@2.48.0':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      '@types/zen-observable': 0.8.3
+      safe-json-stringify: 1.2.0
+      tslib: 2.8.1
+      zen-observable: 0.10.0
+
+  '@amplitude/analytics-core@2.48.1':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      '@types/zen-observable': 0.8.3
+      safe-json-stringify: 1.2.0
+      tslib: 2.8.1
+      zen-observable: 0.10.0
+
+  '@amplitude/plugin-autocapture-browser@1.27.1':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.1
+      tslib: 2.8.1
+
+  '@amplitude/plugin-custom-enrichment-browser@0.1.8':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.0
+      tslib: 2.8.1
+
+  '@amplitude/plugin-event-property-attribution-browser@0.2.0':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.0
+      tslib: 2.8.1
+
+  '@amplitude/plugin-network-capture-browser@1.10.0':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.0
+      tslib: 2.8.1
+
+  '@amplitude/plugin-page-url-enrichment-browser@0.7.10':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.1
+      tslib: 2.8.1
+
+  '@amplitude/plugin-page-view-tracking-browser@2.11.0':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.0
+      tslib: 2.8.1
+
+  '@amplitude/plugin-web-vitals-browser@1.1.32':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.0
+      tslib: 2.8.1
+      web-vitals: 5.1.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3083,6 +3197,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/zen-observable@0.8.3': {}
 
   '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4541,6 +4657,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-json-stringify@1.2.0: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -4885,6 +5003,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  web-vitals@5.1.0: {}
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4935,6 +5055,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zen-observable@0.10.0: {}
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

Amplitude analytics SDK를 연동하여 사용자 행동 데이터를 수집합니다.

## 💡 참고 사항

### 1. 공통
- 페이지 체류 시간 측정 (60초 비활성 시 종료, 최대 15분 cap) `useDwellTime.ts`
- 스크롤 뎁스 측정 (25 / 50 / 75 / 100%) `useScrollDepth.ts`
- 유입 경로 분류 (Direct / Organic Search / Social / Kakao / Referral) `amplitude-provider.tsx`
- 유저 속성 수집 (신규/재방문 여부, 방문 횟수, 첫/마지막 방문일) `amplitude-provider.tsx`
- UTM 파라미터 자동 수집 `amplitude-provider.tsx`

### 2. 페이지별 이벤트
- 메인: 배너 클릭, 전시/작품 카드 클릭, 더보기 버튼, 문의하기 버튼
- 전체 전시/작품 리스트: 카드 클릭, 필터 클릭, 체류 시간
- GNB: 햄버거 버튼 클릭 경로, 메뉴 클릭 경로
- 전시 소개: CTA 클릭 시점, SNS 링크 클릭, 섹션별 체류 시간
- 작품 목록: 카드 클릭, 카테고리 필터, 뷰모드 변경, 구역 탭 클릭
- 작품 상세: 탭 클릭, 관련 작품 클릭, 이전/다음 작품 네비게이션
- 작가 목록: 작가 카드 클릭 (탐색 소요 시간 포함)
- 작가 상세: SNS 클릭, 작품 카드 클릭, 이전/다음 작가 네비게이션

### 3. 확인 방법
Amplitude 대시보드 → Data → Events 탭에서 수집 이벤트 확인

## 🖥️ 주요 코드 설명

### Amplitude SDK 연동 구조
- AmplitudeProvider가 RootLayout에서 children을 감싸고 있는 구조입니다.
- 각 이벤트를 계산하는 훅을 별도로 작성하여, 필요한 페이지 및 요소들에 주입합니다.(트리거 설정)

#### 1. 초기화 흐름

```
사용자가 페이지 진입
→ AmplitudeProvider (루트 레이아웃에 마운트)
→ initAmplitude() 실행 (SDK 초기화)
→ localStorage에서 방문 기록 읽기
→ Identify로 유저 속성 설정 (신규/재방문, 방문횟수 등)
→ Platform Entry 이벤트 발송 (유입경로, UTM 등)
```

#### 2. 페이지 공통 트래킹

```
페이지 렌더링
→ PageTracker 또는 ExhibitionPageTracker 마운트
→ useDwellTime: scroll/click/touch/keyboard 감지 시작
→ useScrollDepth: IntersectionObserver로 25/50/75/100% 감지
→ 페이지 이탈 시 → Page Dwell Time 이벤트 발송
```

#### 3. 섹션 체류 시간

```
각 섹션에 data-section="이름" 속성 부여
→ useSectionTime: IntersectionObserver로 각 섹션 진입/이탈 시간 측정
→ 페이지 이탈 시 → Most Visited Section 이벤트 발송
```

#### 4. 개별 이벤트

```
유저 클릭/인터랙션
→ TrackedLink / track() 직접 호출
→ 각 이벤트명 + 속성값 Amplitude로 전송
```

#### 파일 구조

```
lib/amplitude.ts               # SDK 초기화, track 함수
providers/amplitude-provider.tsx  # 유저속성, 유입경로 설정
lib/hooks/
  useDwellTime.ts              # 체류 시간
  useScrollDepth.ts            # 스크롤 뎁스
  useSectionTime.ts            # 섹션별 체류
components/common/
  PageTracker.tsx              # 메인 페이지용
  ExhibitionPageTracker.tsx    # 전시 페이지용 (경로 자동감지)
  SectionTimeTracker.tsx       # 섹션 체류 래퍼
  TrackedLink.tsx              # 클릭 추적 링크
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #77 
