### PR TITLE
[SEO] 검색엔진 최적화 - 메타태그, sitemap, robots, JSON-LD 적용

### DIFF
--- a/apps/client/app/(main)/page.tsx
+++ b/apps/client/app/(main)/page.tsx
@@ -1,4 +1,5 @@
 import { buttonVariants } from "components";
+import type { Metadata } from "next";
 import { Divider } from "@/components/common/Divider/Divider";
 import MainFooter from "@/components/common/Footer/MainFooter";
 import { PageTracker } from "@/components/common/PageTracker";
@@ -14,6 +15,27 @@ import { TrackedExhibitionLink } from "./_components/TrackedExhibitionLink";
 // import { MOCK_BANNERS } from "./_mocks/banner";
 // import { MOCK_EXHIBITIONS } from "./_mocks/exhibition";
 // import { MOCK_SECTIONS } from "./_mocks/section";
+
+export const metadata: Metadata = {
+	title: "두록 | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+	description: "두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.",
+	alternates: {
+		canonical: "https://dolog.kr",
+	},
+	openGraph: {
+		type: "website",
+		url: "https://dolog.kr",
+		title: "두록 | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+		description: "두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.",
+		images: [{ url: "/images/og-default.png" }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "두록 | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+		description: "두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.",
+		images: ["/images/og-default.png"],
+	},
+};
 
 export default async function MainPage() {
 	const [banners, mainExhibitions, mainArtworks] = await Promise.all([

--- a/apps/client/app/(main)/page.tsx
+++ b/apps/client/app/(main)/page.tsx
@@ -17,24 +17,50 @@ import { TrackedExhibitionLink } from "./_components/TrackedExhibitionLink";
 // import { MOCK_SECTIONS } from "./_mocks/section";
 
 export const metadata: Metadata = {
-	title: "두록 | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
-	description: "두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.",
+	title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+	description:
+		"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 	alternates: {
 		canonical: "https://dolog.kr",
 	},
 	openGraph: {
 		type: "website",
 		url: "https://dolog.kr",
-		title: "두록 | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
-		description: "두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.",
+		siteName: "두록(Dolog)",
+		locale: "ko_KR",
+		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+		description:
+			"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 		images: [{ url: "/images/og-default.png" }],
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "두록 | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
-		description: "두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.",
+		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+		description:
+			"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 		images: ["/images/og-default.png"],
 	},
+};
+
+const organizationJsonLd = {
+	"@context": "https://schema.org",
+	"@type": "Organization",
+	name: "두록",
+	alternateName: "Dolog",
+	url: "https://dolog.kr/",
+	logo: "https://dolog.kr/logo.svg",
+	description:
+		"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+	sameAs: ["https://www.instagram.com/dolog.archive"],
+};
+
+const websiteJsonLd = {
+	"@context": "https://schema.org",
+	"@type": "WebSite",
+	name: "두록",
+	alternateName: "Dolog",
+	url: "https://dolog.kr/",
+	description: "대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
 };
 
 export default async function MainPage() {
@@ -56,6 +82,14 @@ export default async function MainPage() {
 
 	return (
 		<div className="flex flex-col">
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+			/>
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+			/>
 			<PageTracker pageName="main" />
 			<Header />
 			<Banner banners={displayBanners} />

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -21,14 +21,28 @@ export async function generateMetadata({
 	const uuid = await resolveExhibitionId(exhibitionId);
 	const meta = uuid ? await getExhibitionMeta(uuid) : null;
 
+	const canonicalUrl = `https://dolog.kr/${exhibitionId}`;
+	const ogImage = meta?.image ? [{ url: meta.image }] : [{ url: "/images/og-default.png" }];
+
 	return {
 		title: meta?.title ?? "두록",
 		description: meta?.description ?? "우리의 졸업 전시, 더 오래 기록하는 방법",
 		icons: { icon: meta?.favicon ?? "/favicon.ico" },
+		alternates: {
+			canonical: canonicalUrl,
+		},
 		openGraph: {
+			type: "website",
+			url: canonicalUrl,
 			title: meta?.title ?? "두록",
 			description: meta?.description ?? "우리의 졸업 전시, 더 오래 기록하는 방법",
-			images: meta?.image ? [{ url: meta.image }] : [{ url: "/images/og-default.png" }],
+			images: ogImage,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: meta?.title ?? "두록",
+			description: meta?.description ?? "우리의 졸업 전시, 더 오래 기록하는 방법",
+			images: ogImage.map((img) => img.url),
 		},
 	};
 }

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -24,15 +24,16 @@ export async function generateMetadata({
 		uuid ? getExhibitionDetail(uuid) : null,
 	]);
 
-	const titleParts = [
-		meta?.title ?? detail?.title,
-		detail && `${detail.univName} ${detail.deptName}`,
-	].filter(Boolean);
-	const title = titleParts.length > 0 ? titleParts.join(" | ") : "두록";
+	const exhibitionName = meta?.title ?? detail?.title ?? "";
+	const orgName = detail ? `${detail.univName} ${detail.deptName}` : "";
+	const exhibitionType = detail?.exhibitionType ?? "";
+
+	const titleBase = [orgName, exhibitionType, exhibitionName].filter(Boolean).join(" ");
+	const title = titleBase ? `${titleBase} | 두록(Dolog)` : "두록(Dolog)";
 
 	const autoDescription = detail
-		? `${detail.univName} ${detail.deptName}${detail.exhibitionType ? ` ${detail.exhibitionType}` : ""} 전시 ${detail.title}. 두록(DOLOG)에서 확인하세요.`
-		: "우리의 졸업 전시, 더 오래 기록하는 방법";
+		? `${orgName}${exhibitionType ? ` ${exhibitionType}` : ""} ${exhibitionName}의 온라인 전시 아카이브입니다. 전시, 작품 정보와 참여 작가를 두록(Dolog)에서 확인할 수 있습니다.`
+		: "두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.";
 	const description = meta?.description ?? autoDescription;
 
 	const canonicalUrl = `https://dolog.kr/${exhibitionId}`;
@@ -48,6 +49,8 @@ export async function generateMetadata({
 		openGraph: {
 			type: "website",
 			url: canonicalUrl,
+			siteName: "두록(Dolog)",
+			locale: "ko_KR",
 			title,
 			description,
 			images: ogImage,

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { ExhibitionPageTracker } from "@/components/common/ExhibitionPageTracker";
 import MainFooter from "@/components/common/Footer/MainFooter";
 import SchoolFooter from "@/components/common/Footer/SchoolFooter";
-import { getExhibitions } from "@/lib/api/exhibition";
+import { getExhibitionDetail, getExhibitions } from "@/lib/api/exhibition";
 import { getExhibitionFooter } from "@/lib/api/layout";
 import { ThemeProvider } from "@/providers/theme-providers";
 import { getExhibitionCustom } from "./_api/getExhibitionCustom";
@@ -19,14 +19,28 @@ export async function generateMetadata({
 }): Promise<Metadata> {
 	const { exhibitionId } = await params;
 	const uuid = await resolveExhibitionId(exhibitionId);
-	const meta = uuid ? await getExhibitionMeta(uuid) : null;
+	const [meta, detail] = await Promise.all([
+		uuid ? getExhibitionMeta(uuid) : null,
+		uuid ? getExhibitionDetail(uuid) : null,
+	]);
+
+	const titleParts = [
+		meta?.title ?? detail?.title,
+		detail && `${detail.univName} ${detail.deptName}`,
+	].filter(Boolean);
+	const title = titleParts.length > 0 ? titleParts.join(" | ") : "두록";
+
+	const autoDescription = detail
+		? `${detail.univName} ${detail.deptName}${detail.exhibitionType ? ` ${detail.exhibitionType}` : ""} 전시 ${detail.title}. 두록(DOLOG)에서 확인하세요.`
+		: "우리의 졸업 전시, 더 오래 기록하는 방법";
+	const description = meta?.description ?? autoDescription;
 
 	const canonicalUrl = `https://dolog.kr/${exhibitionId}`;
 	const ogImage = meta?.image ? [{ url: meta.image }] : [{ url: "/images/og-default.png" }];
 
 	return {
-		title: meta?.title ?? "두록",
-		description: meta?.description ?? "우리의 졸업 전시, 더 오래 기록하는 방법",
+		title,
+		description,
 		icons: { icon: meta?.favicon ?? "/favicon.ico" },
 		alternates: {
 			canonical: canonicalUrl,
@@ -34,14 +48,14 @@ export async function generateMetadata({
 		openGraph: {
 			type: "website",
 			url: canonicalUrl,
-			title: meta?.title ?? "두록",
-			description: meta?.description ?? "우리의 졸업 전시, 더 오래 기록하는 방법",
+			title,
+			description,
 			images: ogImage,
 		},
 		twitter: {
 			card: "summary_large_image",
-			title: meta?.title ?? "두록",
-			description: meta?.description ?? "우리의 졸업 전시, 더 오래 기록하는 방법",
+			title,
+			description,
 			images: ogImage.map((img) => img.url),
 		},
 	};
@@ -57,9 +71,6 @@ export default async function ExhibitionLayout({
 	const { exhibitionId } = await params;
 	const uuid = await resolveExhibitionId(exhibitionId);
 	const custom = uuid ? await getExhibitionCustom(uuid) : null;
-
-	// TODO : /{slug} 또는 uuid 단건 조회 api get 가능할지 물어보기
-	// 예상 : const exhibition = await getExhibitionBySlug(exhibitionId);
 	const exhibitions = await getExhibitions();
 	const exhibition = exhibitions.find((e) => e.slug === exhibitionId);
 	exhibitions.find((e) => e.id === uuid);

--- a/apps/client/app/[exhibitionId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/page.tsx
@@ -48,8 +48,34 @@ export default async function ExhibitionDetailPage({ params }: ExhibitionDetailP
 	const hostData = host;
 	const snsData = sns;
 
+	const jsonLd = {
+		"@context": "https://schema.org",
+		"@type": "ExhibitionEvent",
+		name: exhibitionData.title,
+		description: exhibitionData.description,
+		startDate: exhibitionData.startDate,
+		endDate: exhibitionData.endDate,
+		image: exhibitionData.exhibitionImg,
+		location: {
+			"@type": "Place",
+			address: {
+				"@type": "PostalAddress",
+				streetAddress: exhibitionData.location.address,
+			},
+		},
+		organizer: {
+			"@type": "Organization",
+			name: `${exhibitionData.univName} ${exhibitionData.deptName}`,
+		},
+		url: `https://dolog.kr/${exhibitionId}`,
+	};
+
 	return (
 		<main>
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+			/>
 			<SectionTimeTracker
 				pageName="exhibition_intro"
 				sections={["intro", "detail", "location", "host"]}

--- a/apps/client/app/[exhibitionId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/page.tsx
@@ -50,12 +50,14 @@ export default async function ExhibitionDetailPage({ params }: ExhibitionDetailP
 
 	const jsonLd = {
 		"@context": "https://schema.org",
-		"@type": "ExhibitionEvent",
-		name: exhibitionData.title,
-		description: exhibitionData.description,
+		"@type": "Event",
+		name: `${exhibitionData.univName} ${exhibitionData.deptName}${exhibitionData.exhibitionType ? ` ${exhibitionData.exhibitionType}` : ""} ${exhibitionData.title}`,
+		description: `${exhibitionData.univName} ${exhibitionData.deptName}${exhibitionData.exhibitionType ? ` ${exhibitionData.exhibitionType}` : ""} ${exhibitionData.title}의 온라인 전시 아카이브입니다. 전시, 작품 정보와 참여 작가를 두록(Dolog)에서 확인할 수 있습니다.`,
 		startDate: exhibitionData.startDate,
 		endDate: exhibitionData.endDate,
 		image: exhibitionData.exhibitionImg,
+		eventAttendanceMode: "https://schema.org/OnlineEventAttendanceMode",
+		eventStatus: "https://schema.org/EventScheduled",
 		location: {
 			"@type": "Place",
 			address: {
@@ -66,6 +68,13 @@ export default async function ExhibitionDetailPage({ params }: ExhibitionDetailP
 		organizer: {
 			"@type": "Organization",
 			name: `${exhibitionData.univName} ${exhibitionData.deptName}`,
+		},
+		publisher: {
+			"@type": "Organization",
+			name: "두록",
+			alternateName: "Dolog",
+			url: "https://dolog.kr/",
+			sameAs: ["https://www.instagram.com/dolog.archive"],
 		},
 		url: `https://dolog.kr/${exhibitionId}`,
 	};

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -7,12 +7,25 @@ export const metadata: Metadata = {
 	title: "두록",
 	description: "우리의 졸업 전시, 더 오래 기록하는 방법",
 	metadataBase: new URL("https://dolog.kr"),
+	alternates: {
+		canonical: "https://dolog.kr",
+	},
 	openGraph: {
 		type: "website",
 		url: "https://dolog.kr",
 		title: "두록",
 		description: "우리의 졸업 전시, 더 오래 기록하는 방법",
 		images: [{ url: "/images/og-default.png" }],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "두록",
+		description: "우리의 졸업 전시, 더 오래 기록하는 방법",
+		images: ["/images/og-default.png"],
+	},
+	verification: {
+		google: "y8A4PmZMH-PpvOKHTtdyybamDdFzYf6VS-LTFWfA0RA",
+		other: { "naver-site-verification": "d88474d58d7d9e08cdc8098c00e6e4cb9edc1c59" },
 	},
 };
 

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -1,6 +1,6 @@
 import "./globals.css";
-import type { Metadata } from "next";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import type { Metadata } from "next";
 import { AmplitudeProvider } from "@/providers/amplitude-provider";
 
 export const metadata: Metadata = {

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -23,6 +23,10 @@ export const metadata: Metadata = {
 		description: "우리의 졸업 전시, 더 오래 기록하는 방법",
 		images: ["/images/og-default.png"],
 	},
+	robots: {
+		index: true,
+		follow: true,
+	},
 	verification: {
 		google: "y8A4PmZMH-PpvOKHTtdyybamDdFzYf6VS-LTFWfA0RA",
 		other: { "naver-site-verification": "d88474d58d7d9e08cdc8098c00e6e4cb9edc1c59" },

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -4,8 +4,9 @@ import type { Metadata } from "next";
 import { AmplitudeProvider } from "@/providers/amplitude-provider";
 
 export const metadata: Metadata = {
-	title: "두록",
-	description: "우리의 졸업 전시, 더 오래 기록하는 방법",
+	title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+	description:
+		"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 	metadataBase: new URL("https://dolog.kr"),
 	alternates: {
 		canonical: "https://dolog.kr",
@@ -13,14 +14,18 @@ export const metadata: Metadata = {
 	openGraph: {
 		type: "website",
 		url: "https://dolog.kr",
-		title: "두록",
-		description: "우리의 졸업 전시, 더 오래 기록하는 방법",
+		siteName: "두록(Dolog)",
+		locale: "ko_KR",
+		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+		description:
+			"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 		images: [{ url: "/images/og-default.png" }],
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "두록",
-		description: "우리의 졸업 전시, 더 오래 기록하는 방법",
+		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
+		description:
+			"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 		images: ["/images/og-default.png"],
 	},
 	robots: {

--- a/apps/client/app/robots.ts
+++ b/apps/client/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: {
+			userAgent: "*",
+			allow: "/",
+		},
+		sitemap: "https://dolog.kr/sitemap.xml",
+	};
+}

--- a/apps/client/app/sitemap.ts
+++ b/apps/client/app/sitemap.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+import { getExhibitions } from "@/lib/api/exhibition";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	const exhibitions = await getExhibitions();
+
+	const exhibitionUrls = exhibitions.map((e) => ({
+		url: `https://dolog.kr/${e.slug ?? e.id}`,
+		lastModified: new Date(),
+		changeFrequency: "monthly" as const,
+		priority: 0.8,
+	}));
+
+	return [
+		{
+			url: "https://dolog.kr",
+			lastModified: new Date(),
+			changeFrequency: "daily",
+			priority: 1,
+		},
+		...exhibitionUrls,
+	];
+}

--- a/apps/client/components/common/Footer/MainFooter.tsx
+++ b/apps/client/components/common/Footer/MainFooter.tsx
@@ -9,13 +9,13 @@ export default function MainFooter() {
 				<div className="flex flex-col gap-1">
 					<p className="text-body2 text-lighter">
 						두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.
+						<br />
+						졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.
 					</p>
 					<p className="text-body2 text-lighter">dologarchive@gmail.com</p>
 				</div>
 				<div className="h-3 w-full" />
-				<p className="text-body3-bold text-lightest">
-					Website powered by 두록(DOLOG) / 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼
-				</p>
+				<p className="text-body3-bold text-lightest">Website powered by DOLOG</p>
 			</div>
 		</footer>
 	);

--- a/apps/client/components/common/Footer/MainFooter.tsx
+++ b/apps/client/components/common/Footer/MainFooter.tsx
@@ -7,11 +7,15 @@ export default function MainFooter() {
 				<Image src="/images/logo.svg" alt="DoLog Logo" width={50} height={25} />
 				<div className="h-5 w-full" />
 				<div className="flex flex-col gap-1">
-					<p className="text-body2 text-lighter">우리의 졸업 전시, 더 오래 기록하는 방법</p>
+					<p className="text-body2 text-lighter">
+						두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.
+					</p>
 					<p className="text-body2 text-lighter">dologarchive@gmail.com</p>
 				</div>
 				<div className="h-3 w-full" />
-				<p className="text-body3-bold text-lightest ">Website powered by DOLOG</p>
+				<p className="text-body3-bold text-lightest">
+					Website powered by 두록(DOLOG) / 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼
+				</p>
 			</div>
 		</footer>
 	);

--- a/apps/client/components/common/Footer/SchoolFooter.tsx
+++ b/apps/client/components/common/Footer/SchoolFooter.tsx
@@ -35,7 +35,8 @@ export default function SchoolFooter({
 				<div className="h-3 w-full" />
 				<p className="text-lightest text-body3-bold">
 					{copyright} <br />
-					All Rights reserved.
+					Website powered by 두록(DOLOG) <br />
+					대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼
 				</p>
 				<div className="h-7 w-full" />
 				<Image src={logoSrc || "/images/logo.svg"} alt={`${title} Logo`} width={60} height={18} />

--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,9 @@
 			},
 			"complexity": {
 				"noForEach": "off"
+			},
+			"security": {
+				"noDangerouslySetInnerHtml": "off"
 			}
 		}
 	},


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

### 검색엔진 등록 및 소유권 인증
  - Google / Naver Search Console 소유권 인증 메타태그 삽입 
                                              
  ### sitemap / robots.txt                                                        
  - `app/sitemap.ts` 생성 → `/sitemap.xml` 자동 생성 (전시 페이지 동적 포함)
  - `app/robots.ts` 생성 → `/robots.txt` 자동 생성
                                          
  ### 메인 페이지 SEO                                                             
  - title, description, canonical, robots, OG, Twitter Card 적용
  - Organization / WebSite JSON-LD 구조화 데이터 추가
                                                                                  
  ### 전시 페이지 SEO                     
  - `generateMetadata`에서 학교명, 단과대명, 전시 유형, 전시명을 조합해 title/description 자동 생성
  - canonical URL, OG(`siteName`, `locale` 포함), Twitter Card 적용
  - Event JSON-LD 구조화 데이터 추가 (organizer, publisher, eventAttendanceMode 포함)                                                                           
                                          
  ### 푸터 문구 수정                                                              
  - MainFooter: 플랫폼 소개 문구 업데이트
  - SchoolFooter: "Website powered by 두록(DOLOG)" 문구 추가

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
- 소유권 인증은 배포 후 Search Console에서 인증 버튼 클릭 필요합니다.
- 전시별 OG 이미지는 백엔드에서 `meta.image` 필드 제공 시 자동 반영합니다. 없을 경우 기본 이미지 fallback하도록 처리했습니다.


## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #114