### PR TITLE
feat: 메인 페이지 진행 중인 전시 fallback 노출

### DIFF
--- a/apps/client/app/(main)/page.tsx
+++ b/apps/client/app/(main)/page.tsx
@@ -6,7 +6,7 @@ import { PageTracker } from "@/components/common/PageTracker";
 import { Title } from "@/components/common/Title/Title";
 import { TrackedLink } from "@/components/common/TrackedLink";
 import { getMainArtworks } from "@/lib/api/artwork";
-import { getBanners, getMainExhibitions } from "@/lib/api/exhibition";
+import { getBanners, getExhibitions, getMainExhibitions } from "@/lib/api/exhibition";
 import Banner from "./_components/Banner";
 import CategorySection from "./_components/CategorySection";
 import ExhibitionCard from "./_components/ExhibitionCard";
@@ -64,13 +64,15 @@ const websiteJsonLd = {
 };
 
 export default async function MainPage() {
-	const [banners, mainExhibitions, mainArtworks] = await Promise.all([
+	const [banners, mainExhibitions, allExhibitions, mainArtworks] = await Promise.all([
 		getBanners(),
 		getMainExhibitions(),
+		getExhibitions(),
 		getMainArtworks(),
 	]);
 	const displayBanners = banners;
-	const displayExhibitions = mainExhibitions;
+	const displayExhibitions =
+		mainExhibitions.length > 0 ? mainExhibitions : allExhibitions.slice(0, 3);
 	const allArtworks = mainArtworks.map((a) => ({
 		id: a.id,
 		title: a.title,
@@ -95,54 +97,27 @@ export default async function MainPage() {
 			<Banner banners={displayBanners} />
 
 			<section className="flex flex-col px-4 pt-6 pb-6 ">
-				{displayExhibitions.length > 0 ? (
-					<>
-						<Title title="진행 중인 전시" />
-						<div className="flex flex-col gap-4 mt-4">
-							{displayExhibitions.slice(0, 3).map((exhibition) => (
-								<TrackedExhibitionLink
-									key={exhibition.id}
-									href={`/${exhibition.slug ?? exhibition.id}`}
-									exhibitionId={exhibition.id}
-									exhibitionTitle={exhibition.title}
-								>
-									<ExhibitionCard {...exhibition} />
-								</TrackedExhibitionLink>
-							))}
-						</div>
-						<TrackedLink
-							href="/exhibitions"
-							eventName="More Button Clicked"
-							eventProps={{ target: "exhibitions", page: "main" }}
-							className={buttonVariants({ variant: "assistive", className: "mt-7 w-full" })}
+				<Title title="진행 중인 전시" />
+				<div className="flex flex-col gap-4 mt-4">
+					{displayExhibitions.slice(0, 3).map((exhibition) => (
+						<TrackedExhibitionLink
+							key={exhibition.id}
+							href={`/${exhibition.slug ?? exhibition.id}`}
+							exhibitionId={exhibition.id}
+							exhibitionTitle={exhibition.title}
 						>
-							더보기
-						</TrackedLink>
-					</>
-				) : (
-					<>
-						<div className="flex flex-col gap-4 mt-4">
-							{displayExhibitions.slice(0, 3).map((exhibition) => (
-								<TrackedExhibitionLink
-									key={exhibition.id}
-									href={`/${exhibition.slug ?? exhibition.id}`}
-									exhibitionId={exhibition.id}
-									exhibitionTitle={exhibition.title}
-								>
-									<ExhibitionCard {...exhibition} />
-								</TrackedExhibitionLink>
-							))}
-						</div>
-						<TrackedLink
-							href="/exhibitions"
-							eventName="More Button Clicked"
-							eventProps={{ target: "exhibitions", page: "main" }}
-							className={buttonVariants({ variant: "assistive", className: "mt-7 w-full" })}
-						>
-							전체 전시 보러가기
-						</TrackedLink>
-					</>
-				)}
+							<ExhibitionCard {...exhibition} />
+						</TrackedExhibitionLink>
+					))}
+				</div>
+				<TrackedLink
+					href="/exhibitions"
+					eventName="More Button Clicked"
+					eventProps={{ target: "exhibitions", page: "main" }}
+					className={buttonVariants({ variant: "assistive", className: "mt-7 w-full" })}
+				>
+					더보기
+				</TrackedLink>
 			</section>
 
 			<Divider fullBleed={false} />

--- a/apps/client/app/(main)/page.tsx
+++ b/apps/client/app/(main)/page.tsx
@@ -19,7 +19,7 @@ import { TrackedExhibitionLink } from "./_components/TrackedExhibitionLink";
 export const metadata: Metadata = {
 	title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
 	description:
-		"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+		"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 	alternates: {
 		canonical: "https://dolog.kr",
 	},
@@ -30,14 +30,14 @@ export const metadata: Metadata = {
 		locale: "ko_KR",
 		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
 		description:
-			"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+			"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 		images: [{ url: "/images/og-default.png" }],
 	},
 	twitter: {
 		card: "summary_large_image",
 		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
 		description:
-			"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+			"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 		images: ["/images/og-default.png"],
 	},
 };
@@ -50,7 +50,7 @@ const organizationJsonLd = {
 	url: "https://dolog.kr/",
 	logo: "https://dolog.kr/logo.svg",
 	description:
-		"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+		"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 	sameAs: ["https://www.instagram.com/dolog.archive"],
 };
 

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({
 
 	const autoDescription = detail
 		? `${orgName}${exhibitionType ? ` ${exhibitionType}` : ""} ${exhibitionName}의 온라인 전시 아카이브입니다. 전시, 작품 정보와 참여 작가를 두록(Dolog)에서 확인할 수 있습니다.`
-		: "두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다.";
+		: "두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.";
 	const description = meta?.description ?? autoDescription;
 
 	const canonicalUrl = `https://dolog.kr/${exhibitionId}`;

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -6,7 +6,7 @@ import { AmplitudeProvider } from "@/providers/amplitude-provider";
 export const metadata: Metadata = {
 	title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
 	description:
-		"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+		"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 	metadataBase: new URL("https://dolog.kr"),
 	alternates: {
 		canonical: "https://dolog.kr",
@@ -18,14 +18,14 @@ export const metadata: Metadata = {
 		locale: "ko_KR",
 		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
 		description:
-			"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+			"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 		images: [{ url: "/images/og-default.png" }],
 	},
 	twitter: {
 		card: "summary_large_image",
 		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
 		description:
-			"두록(Dolog)은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+			"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
 		images: ["/images/og-default.png"],
 	},
 	robots: {


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

  - 진행 중인 전시가 없을 시 전체 전시 목록에서 최대 3개 fallback 노출 - 제목은 "진행 중인 전시"로 유지
  - 전시 페이지 SEO fallback description 문구 수정

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

`getMainExhibitions()` 결과가 비어있을 경우 `getExhibitions()`에서 최대 3개 슬라이스됩니다.


## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #114
