### PR TITLE
fix: OG 태그 공유 미리보기 최적화 및 전시 페이지 SEO 개선

### DIFF
--- a/apps/client/app/(main)/page.tsx
+++ b/apps/client/app/(main)/page.tsx
@@ -28,16 +28,14 @@ export const metadata: Metadata = {
 		url: "https://dolog.kr",
 		siteName: "두록(Dolog)",
 		locale: "ko_KR",
-		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
-		description:
-			"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+		title: "두록 DOLOG",
+		description: "대학 전시 및 작품 아카이빙 플랫폼",
 		images: [{ url: "/images/og-default.png" }],
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
-		description:
-			"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+		title: "두록 DOLOG",
+		description: "대학 전시 및 작품 아카이빙 플랫폼",
 		images: ["/images/og-default.png"],
 	},
 };

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -4,6 +4,7 @@ import MainFooter from "@/components/common/Footer/MainFooter";
 import SchoolFooter from "@/components/common/Footer/SchoolFooter";
 import { getExhibitionDetail, getExhibitions } from "@/lib/api/exhibition";
 import { getExhibitionFooter } from "@/lib/api/layout";
+import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 import { ThemeProvider } from "@/providers/theme-providers";
 import { getExhibitionCustom } from "./_api/getExhibitionCustom";
 import { getExhibitionMeta } from "./_api/getExhibitionMeta";
@@ -26,10 +27,13 @@ export async function generateMetadata({
 
 	const exhibitionName = meta?.title ?? detail?.title ?? "";
 	const orgName = detail ? `${detail.univName} ${detail.deptName}` : "";
-	const exhibitionType = detail?.exhibitionType ?? "";
+	const exhibitionType = detail?.exhibitionType
+		? (EXHIBITION_TYPE_LABEL[detail.exhibitionType] ?? detail.exhibitionType)
+		: "";
 
 	const titleBase = [orgName, exhibitionType, exhibitionName].filter(Boolean).join(" ");
 	const title = titleBase ? `${titleBase} | 두록(Dolog)` : "두록(Dolog)";
+	const ogTitle = exhibitionName || "두록(Dolog)";
 
 	const autoDescription = detail
 		? `${orgName}${exhibitionType ? ` ${exhibitionType}` : ""} ${exhibitionName}의 온라인 전시 아카이브입니다. 전시, 작품 정보와 참여 작가를 두록(Dolog)에서 확인할 수 있습니다.`
@@ -51,13 +55,13 @@ export async function generateMetadata({
 			url: canonicalUrl,
 			siteName: "두록(Dolog)",
 			locale: "ko_KR",
-			title,
+			title: ogTitle,
 			description,
 			images: ogImage,
 		},
 		twitter: {
 			card: "summary_large_image",
-			title,
+			title: ogTitle,
 			description,
 			images: ogImage.map((img) => img.url),
 		},

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -16,16 +16,14 @@ export const metadata: Metadata = {
 		url: "https://dolog.kr",
 		siteName: "두록(Dolog)",
 		locale: "ko_KR",
-		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
-		description:
-			"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+		title: "두록 DOLOG",
+		description: "대학 전시 및 작품 아카이빙 플랫폼",
 		images: [{ url: "/images/og-default.png" }],
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "두록(Dolog) | 대학 전시 웹사이트 제작 및 작품 아카이빙 플랫폼",
-		description:
-			"두록은 대학 전시를 위한 전시 웹사이트 제작 및 작품 아카이빙 플랫폼입니다. 졸업 전시, 과제전 및 기타 예술 창작 계열 대학 전시를 온라인으로 기록할 수 있습니다.",
+		title: "두록 DOLOG",
+		description: "대학 전시 및 작품 아카이빙 플랫폼",
 		images: ["/images/og-default.png"],
 	},
 	robots: {


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

  ### 메인 플랫폼 OG 태그 최적화
  - og:title → "두록 DOLOG" (짧게)
  - og:description → "대학 전시 및 작품 아카이빙 플랫폼" (짧게)
  - 검색용 `<title>`, `<meta description>`은 긴 버전 유지

  ### 전시 페이지 OG 태그 최적화
  - og:title → 전시명만 (짧게, 카카오톡 미리보기에서 description 노출되도록)
  - og:description → 자동 생성 설명 유지
  - 검색용 `<title>`, `<meta description>`은 긴 버전 유지

  ### 전시 유형 한글 변환
  - `EXHIBITION_TYPE_LABEL` 상수 적용
  - `assignment` → 과제전, `graduation` → 졸업전시전

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
  - OG 태그는 SNS 공유 미리보기용으로 구글 검색 순위에 직접 영향 없음
  - SEO에 영향 있는 `<title>`, `<meta description>`은 모두 긴 버전으로 유지됨

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #114
