### PR TITLE
feat: 작품 이미지 상세보기 모달 구현, QA 반영

### DIFF
--- a/apps/client/app/(main)/_components/ExhibitionCard.tsx
+++ b/apps/client/app/(main)/_components/ExhibitionCard.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
-import type { ExhibitionItem } from "@/lib/api/exhibition";
 import { EmptyImageFallback } from "@/components/common/EmptyImageFallback/EmptyImageFallback";
+import type { ExhibitionItem } from "@/lib/api/exhibition";
 
 const formatDate = (date: string) => date.replace(/-/g, ".");
 

--- a/apps/client/app/[exhibitionId]/_components/Header.tsx
+++ b/apps/client/app/[exhibitionId]/_components/Header.tsx
@@ -51,7 +51,8 @@ export const Header = ({
 	// 실제 앱 내 이동 여부를 반영하지 못한다. 세션 내 실제 페이지 이동 여부를 직접 추적한다.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname이 바뀔 때마다 다시 실행되어야 함
 	useEffect(() => {
-		sessionStorage.setItem(HAS_INTERNAL_HISTORY_KEY, "true");
+		const hasEnteredBefore = sessionStorage.getItem(HAS_INTERNAL_HISTORY_KEY) !== null;
+		sessionStorage.setItem(HAS_INTERNAL_HISTORY_KEY, hasEnteredBefore ? "true" : "false");
 	}, [pathname]);
 
 	const handleDefaultBack = () => {

--- a/apps/client/app/[exhibitionId]/_components/Header.tsx
+++ b/apps/client/app/[exhibitionId]/_components/Header.tsx
@@ -4,7 +4,7 @@ import { Button } from "components";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DesktopContainer } from "@/components/common/DesktopContainer/DesktopContainer";
 import { track } from "@/lib/amplitude";
 import { useExhibition } from "../_context/ExhibitionContext";
@@ -22,10 +22,17 @@ interface HeaderProps {
 	variant?: "logo" | "back";
 	title?: string;
 	onBackClick?: () => void;
-	onMenuClick?: () => void;
+	showHamburger?: boolean;
 }
 
-export const Header = ({ variant = "logo", title }: HeaderProps) => {
+const HAS_INTERNAL_HISTORY_KEY = "dolog:has-internal-history";
+
+export const Header = ({
+	variant = "logo",
+	title,
+	onBackClick,
+	showHamburger = true,
+}: HeaderProps) => {
 	const router = useRouter();
 	const pathname = usePathname();
 	const { slug, logoImg } = useExhibition();
@@ -40,20 +47,24 @@ export const Header = ({ variant = "logo", title }: HeaderProps) => {
 		return path === "" ? pathname === fullPath : pathname.startsWith(fullPath);
 	};
 
-	const handleBack = () => {
-		const historyLength = window?.history?.length ?? 0;
-		const referrer = document?.referrer ?? "";
-		const host = window?.location?.host ?? "";
+	// 브라우저 진입 시점의 document.referrer는 앱 내 클라이언트 라우팅 이후에도 갱신되지 않아
+	// 실제 앱 내 이동 여부를 반영하지 못한다. 세션 내 실제 페이지 이동 여부를 직접 추적한다.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname이 바뀔 때마다 다시 실행되어야 함
+	useEffect(() => {
+		sessionStorage.setItem(HAS_INTERNAL_HISTORY_KEY, "true");
+	}, [pathname]);
 
-		// 이전 기록이 없거나, 이전 페이지가 우리 서비스 도메인이 아닌 경우
-		const hasNoReferrer = !referrer || !referrer.includes(host);
+	const handleDefaultBack = () => {
+		const hasInternalHistory = sessionStorage.getItem(HAS_INTERNAL_HISTORY_KEY) === "true";
 
-		if (historyLength <= 1 || hasNoReferrer) {
-			router.push(baseUrl);
-		} else {
+		if (hasInternalHistory) {
 			router.back();
+		} else {
+			router.push(baseUrl);
 		}
 	};
+
+	const handleBack = onBackClick ?? handleDefaultBack;
 
 	return (
 		<>
@@ -61,16 +72,16 @@ export const Header = ({ variant = "logo", title }: HeaderProps) => {
 				<DesktopContainer>
 					<div className="flex items-center justify-between py-3 h-11">
 						{variant === "back" ? (
-							<div className="flex items-center gap-2">
+							<div className="flex items-center gap-2 min-w-0">
 								<button
 									type="button"
 									onClick={handleBack}
 									aria-label="뒤로가기"
-									className="cursor-pointer"
+									className="cursor-pointer shrink-0"
 								>
 									<Image src="/icons/backBtn.svg" alt="뒤로가기" width={24} height={24} />
 								</button>
-								{title && <span className="text-body1-bold text-strong">{title}</span>}
+								{title && <span className="text-body1-bold text-strong truncate">{title}</span>}
 							</div>
 						) : (
 							<button type="button" onClick={() => router.push(baseUrl)} className="cursor-pointer">
@@ -133,26 +144,28 @@ export const Header = ({ variant = "logo", title }: HeaderProps) => {
 						)}
 
 						{/* 햄버거 (모바일만) */}
-						<button
-							type="button"
-							onClick={() => {
-								const next = !isSidebarOpen;
-								setIsSidebarOpen(next);
-								if (next) track("GNB Hamburger Clicked", { from_page: pathname });
-							}}
-							className="cursor-pointer min-[721px]:hidden"
-							aria-label={isSidebarOpen ? "메뉴 닫기" : "메뉴 열기"}
-						>
-							{isSidebarOpen ? (
-								<Image src="/icons/close.svg" alt="닫기" width={24} height={24} />
-							) : (
-								<Image src="/icons/leadingBtn.svg" alt="메뉴" width={24} height={24} />
-							)}
-						</button>
+						{showHamburger && (
+							<button
+								type="button"
+								onClick={() => {
+									const next = !isSidebarOpen;
+									setIsSidebarOpen(next);
+									if (next) track("GNB Hamburger Clicked", { from_page: pathname });
+								}}
+								className="cursor-pointer min-[721px]:hidden"
+								aria-label={isSidebarOpen ? "메뉴 닫기" : "메뉴 열기"}
+							>
+								{isSidebarOpen ? (
+									<Image src="/icons/close.svg" alt="닫기" width={24} height={24} />
+								) : (
+									<Image src="/icons/leadingBtn.svg" alt="메뉴" width={24} height={24} />
+								)}
+							</button>
+						)}
 					</div>
 				</DesktopContainer>
 			</header>
-			<Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+			{showHamburger && <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />}
 		</>
 	);
 };

--- a/apps/client/app/[exhibitionId]/_components/Header.tsx
+++ b/apps/client/app/[exhibitionId]/_components/Header.tsx
@@ -47,9 +47,9 @@ export const Header = ({
 		return path === "" ? pathname === fullPath : pathname.startsWith(fullPath);
 	};
 
-	// 브라우저 진입 시점의 document.referrer는 앱 내 클라이언트 라우팅 이후에도 갱신되지 않아
-	// 실제 앱 내 이동 여부를 반영하지 못한다. 세션 내 실제 페이지 이동 여부를 직접 추적한다.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname이 바뀔 때마다 다시 실행되어야 함
+	// 세션 스토리지에 내부 이동 기록 여부를 저장 (back 버튼 정상 동작을 위함)
+	// pathname이 바뀔 때마다 실행되어야 하므로 useEffect에 pathname을 의존성으로 추가함
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname이 바뀔 때마다 다시 실행되어야 함 (해당 주석 삭제 금지 !!)
 	useEffect(() => {
 		const hasEnteredBefore = sessionStorage.getItem(HAS_INTERNAL_HISTORY_KEY) !== null;
 		sessionStorage.setItem(HAS_INTERNAL_HISTORY_KEY, hasEnteredBefore ? "true" : "false");
@@ -135,8 +135,7 @@ export const Header = ({
 									}}
 									size="sm"
 									variant="outline"
-									className="text-body2 text-lighter whitespace-nowrap flex items-center 
-  gap-2 cursor-pointer"
+									className="text-body2 text-lighter whitespace-nowrap flex items-center gap-2 cursor-pointer"
 								>
 									<Image src="/images/logo.svg" alt="DoLog" width={40} height={14} />
 									홈에서 전시 보기

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtistCard.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtistCard.tsx
@@ -23,7 +23,7 @@ export function ArtistCard({ author, profileHref }: ArtistCardProps) {
 	);
 
 	const snsSection = (!!author.email || (author.sns ?? []).length > 0) && (
-		<div className="flex flex-col pb-5 pt-3">
+		<div className="flex flex-col pt-3">
 			<RowList
 				rows={[
 					...(author.email
@@ -93,7 +93,7 @@ export function ArtistCard({ author, profileHref }: ArtistCardProps) {
 				{snsSection}
 
 				{/* 모바일: 버튼 */}
-				<Link href={profileHref} className="min-[721px]:hidden">
+				<Link href={profileHref} className="min-[721px]:hidden pt-5">
 					<Button
 						variant="outline"
 						size="sm"

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
@@ -47,6 +47,7 @@ export function ArtworkDetailClient({
 
 	const [isMainImageViewerOpen, setIsMainImageViewerOpen] = useState(false);
 
+	// 작품 대표 이미지 상세보기 모달 (모바일/데스크탑 분기처리)
 	const handleMainImageClick = () => {
 		if (window.matchMedia("(max-width: 720px)").matches) {
 			setIsMainImageViewerOpen(true);

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import Image from "next/image";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Divider } from "@/components/common/Divider/Divider";
 import { EmptyImageFallback } from "@/components/common/EmptyImageFallback/EmptyImageFallback";
+import { ImageViewerModal } from "@/components/common/ImageViewerModal/ImageViewerModal";
 import { ScrollTabBar } from "@/components/common/ScrollTabBar/ScrollTabBar";
 import { useScrollSpy } from "@/components/common/ScrollTabBar/useScrollSpy";
 import { track } from "@/lib/amplitude";
@@ -20,7 +21,13 @@ import { PostNavigationSection } from "../_components/PostNavigationSection";
 import { RelatedSection } from "../_components/RelatedSection";
 import { YoutubeSection } from "../_components/YoutubeSection";
 
-export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
+export function ArtworkDetailClient({
+	data,
+	hideArtistRole,
+}: {
+	data: ArtworkDetail;
+	hideArtistRole?: boolean;
+}) {
 	const TABS = useMemo(() => {
 		const base = [
 			{ id: "detail", label: "작품 소개" },
@@ -38,26 +45,51 @@ export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
 	const prevArtwork = data.alphabeticalArtworks.find((a) => a.type === "prev");
 	const nextArtwork = data.alphabeticalArtworks.find((a) => a.type === "next");
 
+	const [isMainImageViewerOpen, setIsMainImageViewerOpen] = useState(false);
+
+	const handleMainImageClick = () => {
+		if (window.matchMedia("(max-width: 720px)").matches) {
+			setIsMainImageViewerOpen(true);
+			return;
+		}
+		// TODO: PC 상세보기 모달 구현 예정
+	};
+
 	return (
 		<div className="flex flex-col">
 			<Header variant="back" />
 
-			<div className="w-full h-auto min-[721px]:flex min-[721px]:justify-center min-[721px]:max-h-[70vh] min-[721px]:overflow-hidden">
+			<div className="w-full">
 				{data.mainImage ? (
-					<Image
-						src={data.mainImage}
-						alt={data.title}
-						width={0}
-						height={0}
-						sizes="100vw"
-						className="w-full h-auto min-[721px]:w-auto min-[721px]:max-h-[70vh] min-[721px]:object-contain"
-						priority
-					/>
+					<button
+						type="button"
+						onClick={handleMainImageClick}
+						className="relative block w-full aspect-video cursor-pointer overflow-hidden min-[721px]:max-h-[400px]"
+						aria-label="작품 대표 이미지 전체보기"
+					>
+						<Image
+							src={data.mainImage}
+							alt={data.title}
+							fill
+							sizes="100vw"
+							className="object-cover"
+							priority
+						/>
+					</button>
 				) : (
-					<EmptyImageFallback className="w-full aspect-video" />
+					<EmptyImageFallback className="w-full aspect-video min-[721px]:max-h-[400px]" />
 				)}
 			</div>
-			<InfoSection data={data} />
+			{data.mainImage && (
+				<ImageViewerModal
+					open={isMainImageViewerOpen}
+					onOpenChange={setIsMainImageViewerOpen}
+					src={data.mainImage}
+					alt={data.title}
+					title={data.title}
+				/>
+			)}
+			<InfoSection data={data} hideArtistRole={hideArtistRole} />
 			<LocationSection locationImageUrl={data.locationMap} />
 			<section
 				data-section="detail"
@@ -94,7 +126,9 @@ export function ArtworkDetailClient({ data }: { data: ArtworkDetail }) {
 			{data.sameCategoryArtworks && data.sameCategoryArtworks.length > 0 && (
 				<RelatedSection artworks={data.sameCategoryArtworks} artworkTitle={data.title} />
 			)}
-			<PostNavigationSection prevArtwork={prevArtwork} nextArtwork={nextArtwork} />
+			{(prevArtwork || nextArtwork) && (
+				<PostNavigationSection prevArtwork={prevArtwork} nextArtwork={nextArtwork} />
+			)}
 
 			<ScrollTabBar
 				tabs={TABS}

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/InfoSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/InfoSection.tsx
@@ -14,10 +14,11 @@ import type { ArtworkDetail } from "@/lib/api/artwork";
 
 interface InfoSectionProps {
 	data: ArtworkDetail;
+	hideArtistRole?: boolean;
 }
 
 // RowList를 위한 작가정보 map
-export const InfoSection = ({ data }: InfoSectionProps) => {
+export const InfoSection = ({ data, hideArtistRole }: InfoSectionProps) => {
 	const categories = data.category ? [data.category] : [];
 	const artistRows = data.participants.map((participant) => ({
 		label: participant.nameKo,
@@ -40,10 +41,11 @@ export const InfoSection = ({ data }: InfoSectionProps) => {
 						</p>
 					)}
 				</div>
-				{/* TODO : 추후 개선 논의 필요 (이번 전시에서만 [이름-역할] 영역 제외)  */}
-				{/* <div className="mt-2.5">
-				<RowList rows={artistRows} />
-			</div> */}
+				{!hideArtistRole && (
+					<div className="mt-2.5">
+						<RowList rows={artistRows} />
+					</div>
+				)}
 			</DesktopContainer>
 		</section>
 	);

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/PhotoSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/PhotoSection.tsx
@@ -3,6 +3,7 @@ import { Button } from "components";
 import Image from "next/image";
 import { useState } from "react";
 import { DesktopContainer } from "@/components/common/DesktopContainer/DesktopContainer";
+import { ImageViewerModal } from "@/components/common/ImageViewerModal/ImageViewerModal";
 import { Modal } from "@/components/common/Modal/Modal";
 import type { ArtworkDetail } from "@/lib/api/artwork";
 
@@ -12,31 +13,60 @@ import type { ArtworkDetail } from "@/lib/api/artwork";
  */
 
 interface PhotoSectionProps {
-	data: Pick<ArtworkDetail, "detailImages" | "purchaseUrl">;
+	data: Pick<ArtworkDetail, "detailImages" | "purchaseUrl" | "title">;
 }
 
 export const PhotoSection = ({ data }: PhotoSectionProps) => {
 	const [isOpen, setIsOpen] = useState(false);
+	const [viewerImage, setViewerImage] = useState<{ src: string; alt: string } | null>(null);
+
+	const handleImageClick = (src: string, alt: string) => {
+		if (window.matchMedia("(max-width: 720px)").matches) {
+			setViewerImage({ src, alt });
+			return;
+		}
+		// TODO: PC 상세보기 모달 구현 예정
+	};
+	const { purchaseUrl } = data;
+
 	if (!data.detailImages || data.detailImages.length === 0) return null;
 
 	return (
 		<section className="flex flex-col pb-6">
 			<DesktopContainer>
 				{/* 작품소개 상세사진 - 선택값 */}
-				{data.detailImages.map((img, index) => (
-					<div key={index} className="relative w-full">
-						<Image
-							src={img.imageUrl}
-							alt={img.description ?? `작품 상세 이미지 ${index + 1}`}
-							width={0}
-							height={0}
-							sizes="100vw"
-							className="w-full h-auto"
-						/>
-					</div>
-				))}
+				{data.detailImages.map((img, index) => {
+					const alt = img.description ?? `작품 상세 이미지 ${index + 1}`;
+					return (
+						<button
+							key={img.imageUrl}
+							type="button"
+							onClick={() => handleImageClick(img.imageUrl, alt)}
+							className="relative w-full cursor-pointer"
+							aria-label={`${alt} 전체보기`}
+						>
+							<Image
+								src={img.imageUrl}
+								alt={alt}
+								width={0}
+								height={0}
+								sizes="100vw"
+								className="w-full h-auto"
+							/>
+						</button>
+					);
+				})}
+				{viewerImage && (
+					<ImageViewerModal
+						open={!!viewerImage}
+						onOpenChange={(open) => !open && setViewerImage(null)}
+						src={viewerImage.src}
+						alt={viewerImage.alt}
+						title={data.title}
+					/>
+				)}
 				{/* 구매링크 - 선택값 */}
-				{data.purchaseUrl && (
+				{purchaseUrl && (
 					<>
 						<Button variant="main" className="mt-6" onClick={() => setIsOpen(true)}>
 							작품 구매하기
@@ -50,7 +80,7 @@ export const PhotoSection = ({ data }: PhotoSectionProps) => {
 								{ text: "돌아가기", onClick: () => setIsOpen(false), variant: "secondary" },
 								{
 									text: "이동하기",
-									onClick: () => window.open(data.purchaseUrl!, "_blank"),
+									onClick: () => window.open(purchaseUrl, "_blank"),
 									variant: "primary",
 								},
 							]}

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/PhotoSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/PhotoSection.tsx
@@ -20,6 +20,7 @@ export const PhotoSection = ({ data }: PhotoSectionProps) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [viewerImage, setViewerImage] = useState<{ src: string; alt: string } | null>(null);
 
+	// 작품 상세 이미지 상세보기 모달 (모바일/데스크탑 분기처리)
 	const handleImageClick = (src: string, alt: string) => {
 		if (window.matchMedia("(max-width: 720px)").matches) {
 			setViewerImage({ src, alt });

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/page.tsx
@@ -54,5 +54,9 @@ export default async function ArtworkDetailPage({ params }: ArtworkDetailPagePro
 		);
 	}
 
-	return <ArtworkDetailClient data={data} />;
+	// 특정 전시에서만 작가 역할 영역 숨김 처리 [동국대 서양화과]
+	const HIDE_ARTIST_ROLE_EXHIBITION_IDS = new Set(["5918413e-3bb4-4237-ae4d-c55d8f025f34"]);
+	const hideArtistRole = HIDE_ARTIST_ROLE_EXHIBITION_IDS.has(uuid);
+
+	return <ArtworkDetailClient data={data} hideArtistRole={hideArtistRole} />;
 }

--- a/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
@@ -162,7 +162,7 @@ export function ArtworkListSection({
 								>
 									{isMultiZone && <Title title={zone.zoneName} />}
 									{isMultiZone && zone.description && (
-										<p className="text-body2 mb-4">{zone.description}</p>
+										<p className="text-body2 mb-4 whitespace-pre-wrap">{zone.description}</p>
 									)}
 									{viewMode === "grid" ? (
 										<CardGrid

--- a/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
@@ -162,7 +162,7 @@ export function ArtworkListSection({
 								>
 									{isMultiZone && <Title title={zone.zoneName} />}
 									{isMultiZone && zone.description && (
-										<p className="text-body2 mb-4 whitespace-pre-wrap">{zone.description}</p>
+										<p className="text-body2 text-light mb-4 whitespace-pre-wrap">{zone.description}</p>
 									)}
 									{viewMode === "grid" ? (
 										<CardGrid

--- a/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
@@ -162,7 +162,7 @@ export function ArtworkListSection({
 								>
 									{isMultiZone && <Title title={zone.zoneName} />}
 									{isMultiZone && zone.description && (
-										<p className="text-body2 text-light mb-4">{zone.description}</p>
+										<p className="text-body2 mb-4">{zone.description}</p>
 									)}
 									{viewMode === "grid" ? (
 										<CardGrid

--- a/apps/client/app/[exhibitionId]/artwork/page.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/page.tsx
@@ -35,6 +35,7 @@ export default async function ArtworkListPage({ params }: ArtworkListPageProps) 
 		);
 	}
 
+	// 특정 전시에서만 필터 영역 숨김 처리 [동국대 서양화과]
 	const HIDE_FILTER_EXHIBITION_IDS = new Set(["5918413e-3bb4-4237-ae4d-c55d8f025f34"]);
 	const hideFilter = HIDE_FILTER_EXHIBITION_IDS.has(uuid);
 

--- a/apps/client/app/[exhibitionId]/bts/_components/BehindTheSceneClient.tsx
+++ b/apps/client/app/[exhibitionId]/bts/_components/BehindTheSceneClient.tsx
@@ -84,14 +84,14 @@ export default function BehindTheSceneClient({ items }: BehindTheSceneClientProp
 						<div className="grid grid-cols-1 gap-y-10 w-full min-[721px]:grid-cols-3 min-[721px]:gap-x-5 min-[721px]:gap-y-6">
 							{filtered.map((item) => (
 								<Link key={item.btsId} href={`/${exhibitionId}/bts/${item.btsId}`}>
-									<article className="w-full flex flex-col gap-3 transition-transform duration-200 hover:-translate-y-1">
+									<article className="w-full flex flex-col gap-3 group">
 										<div className="relative w-full aspect-video overflow-hidden">
 											{item.thumbnail ? (
 												<Image
 													src={item.thumbnail}
 													alt={item.title}
 													fill
-													className="object-cover"
+													className="object-cover transition-transform duration-300 group-hover:scale-105"
 												/>
 											) : (
 												<EmptyImageFallback className="w-full h-full" />

--- a/apps/client/components/common/Card/Card.styles.ts
+++ b/apps/client/components/common/Card/Card.styles.ts
@@ -1,8 +1,8 @@
 export const cardStyles = {
-	wrapper: "w-full flex flex-col items-start gap-[12px] transition-transform duration-200",
-	wrapperHover: "hover:-translate-y-1",
+	wrapper: "w-full flex flex-col items-start gap-[12px]",
+	wrapperHover: "group",
 	imageWrapper: "relative w-full aspect-[1/1.414] overflow-hidden ",
-	image: "w-full h-full object-cover",
+	image: "w-full h-full object-cover transition-transform duration-300 group-hover:scale-105",
 	info: "w-full flex flex-col gap-[4px]",
 	title: "text-strong text-head3 break-all",
 	category: "text-light text-body2",

--- a/apps/client/components/common/ImageViewerModal/ImageViewerModal.styles.ts
+++ b/apps/client/components/common/ImageViewerModal/ImageViewerModal.styles.ts
@@ -1,0 +1,19 @@
+export const imageViewerModalStyles = {
+	overlay: "fixed inset-0 bg-bg-normal z-[100] animate-in fade-in duration-200",
+
+	content: "fixed inset-0 z-[101] flex flex-col outline-none animate-in fade-in duration-200",
+
+	imageArea: "relative flex-1 flex items-center justify-center overflow-hidden",
+
+	transformWrapper: "!w-full !h-full",
+
+	transformContent:
+		"!w-full !h-full flex items-center justify-center transform-gpu backface-hidden",
+
+	image: "max-w-full max-h-full object-contain select-none",
+
+	zoomControls: "absolute bottom-6 right-4 z-10 flex flex-col gap-2",
+
+	zoomButton:
+		"p-2 rounded-full bg-white/90 cursor-pointer active:scale-95 transition-transform disabled:opacity-40 disabled:cursor-default",
+};

--- a/apps/client/components/common/ImageViewerModal/ImageViewerModal.tsx
+++ b/apps/client/components/common/ImageViewerModal/ImageViewerModal.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import Image from "next/image";
+import { TransformComponent, TransformWrapper, useControls } from "react-zoom-pan-pinch";
+import { Header } from "@/app/[exhibitionId]/_components/Header";
+import { imageViewerModalStyles } from "./ImageViewerModal.styles";
+
+interface ImageViewerModalProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	src: string;
+	alt: string;
+	title: string;
+}
+
+function ZoomControls() {
+	const { zoomIn, zoomOut } = useControls();
+
+	return (
+		<div className={imageViewerModalStyles.zoomControls}>
+			<button
+				type="button"
+				onClick={() => zoomIn()}
+				className={imageViewerModalStyles.zoomButton}
+				aria-label="확대"
+			>
+				<Image src="/icons/zoomIn.svg" alt="확대" width={24} height={24} />
+			</button>
+			<button
+				type="button"
+				onClick={() => zoomOut()}
+				className={imageViewerModalStyles.zoomButton}
+				aria-label="축소"
+			>
+				<Image src="/icons/zoomOut.svg" alt="축소" width={24} height={24} />
+			</button>
+		</div>
+	);
+}
+
+export const ImageViewerModal = ({
+	open,
+	onOpenChange,
+	src,
+	alt,
+	title,
+}: ImageViewerModalProps) => {
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<Dialog.Portal>
+				<Dialog.Overlay className={imageViewerModalStyles.overlay} />
+				<Dialog.Content className={imageViewerModalStyles.content}>
+					<Dialog.Title className="sr-only">{alt}</Dialog.Title>
+					<Header
+						variant="back"
+						title={title}
+						onBackClick={() => onOpenChange(false)}
+						showHamburger={false}
+					/>
+					<div className={imageViewerModalStyles.imageArea}>
+						<TransformWrapper doubleClick={{ mode: "toggle" }} wheel={{ disabled: true }}>
+							<TransformComponent
+								wrapperClass={imageViewerModalStyles.transformWrapper}
+								contentClass={imageViewerModalStyles.transformContent}
+							>
+								{/* biome-ignore lint/performance/noImgElement: react-zoom-pan-pinch가 순수 img 요소에 transform을 적용해야 함 */}
+								<img src={src} alt={alt} className={imageViewerModalStyles.image} />
+							</TransformComponent>
+							<ZoomControls />
+						</TransformWrapper>
+					</div>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+};

--- a/apps/client/components/common/ImageViewerModal/ImageViewerModal.tsx
+++ b/apps/client/components/common/ImageViewerModal/ImageViewerModal.tsx
@@ -50,7 +50,10 @@ export const ImageViewerModal = ({
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
 			<Dialog.Portal>
 				<Dialog.Overlay className={imageViewerModalStyles.overlay} />
-				<Dialog.Content className={imageViewerModalStyles.content}>
+				<Dialog.Content
+					className={imageViewerModalStyles.content}
+					onOpenAutoFocus={(e) => e.preventDefault()}
+				>
 					<Dialog.Title className="sr-only">{alt}</Dialog.Title>
 					<Header
 						variant="back"

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -25,6 +25,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
+    "react-zoom-pan-pinch": "^4.0.3",
     "remark-breaks": "^4.0.0",
     "tailwind-merge": "^3.5.0",
     "utils": "workspace:*"

--- a/apps/client/public/icons/zoomIn.svg
+++ b/apps/client/public/icons/zoomIn.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10.5" cy="10.5" r="6.5" stroke="#2F3032" stroke-width="1.7"/>
+<path d="M15.4142 15.4142L20 20" stroke="#2F3032" stroke-width="1.7" stroke-linecap="round"/>
+<path d="M10.5 7.5V13.5M7.5 10.5H13.5" stroke="#2F3032" stroke-width="1.7" stroke-linecap="round"/>
+</svg>

--- a/apps/client/public/icons/zoomOut.svg
+++ b/apps/client/public/icons/zoomOut.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10.5" cy="10.5" r="6.5" stroke="#2F3032" stroke-width="1.7"/>
+<path d="M15.4142 15.4142L20 20" stroke="#2F3032" stroke-width="1.7" stroke-linecap="round"/>
+<path d="M7.5 10.5H13.5" stroke="#2F3032" stroke-width="1.7" stroke-linecap="round"/>
+</svg>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.2.1
@@ -103,6 +103,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.3)
+      react-zoom-pan-pinch:
+        specifier: ^4.0.3
+        version: 4.0.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
@@ -160,7 +163,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.1.6
-        version: 16.1.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-storybook:
         specifier: ^10.4.6
         version: 10.4.6(eslint@9.39.4(jiti@2.6.1))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
@@ -3637,6 +3640,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-zoom-pan-pinch@4.0.3:
+    resolution: {integrity: sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
 
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
@@ -7816,6 +7826,11 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  react-zoom-pan-pinch@4.0.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react@19.2.3: {}
 


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

- **작품 이미지 상세보기 모달 구현 (모바일뷰)**
- **작품 대표 이미지 크기(비율) 수정** : 모바일뷰, 데스크탑뷰 각각 비율 고정으로 수정
- **작품 둘러보기 섹션 조건부 렌더링** : 선택값 데이터가 없을 경우 섹션 미노출 처리
- **헤더 back 버튼 뒤로가기 로직 수정**
- 이 외 자잘한 간격/개행 수정

## 💡 참고 사항

### 1. 작품 이미지 상세보기 모달 구현
- 구현 완료 부분 : [모바일뷰] 작품 대표 이미지+상세 이미지 모달
- 구현 필요 부분 : [데스크탑뷰] 작품 대표 이미지+상세 이미지 모달

#### 구현 방식
1) ImageViewerModal 컴포넌트 (`ImageViewerModal.tsx`)
- Radix UI Dialog를 기반으로 전체화면 오버레이 모달 구성
- react-zoom-pan-pinch 라이브러리로 핀치/더블탭 확대·축소(TransformWrapper) 및 커스텀 확대·축소 버튼(ZoomControls) 제공
<img width="286" height="618" alt="image" src="https://github.com/user-attachments/assets/fa1f4d9c-e7a5-4034-ad71-d046a67850c8" />

2) 모달 오픈 진입 지점 (2종류)
- `ArtworkDetailClient.tsx` : 대표 이미지 클릭 시
- `PhotoSection.tsx` : 하단 상세 이미지 클릭 시
두 곳 모두 window.matchMedia("(max-width: 720px)")로 모바일 뷰포트에서만 모달을 열도록 분기 (PC 상세보기는 TODO)
모바일과 PC뷰에서의 디자인이 다르므로, 각 뷰에 따른 모달을 분기 처리하는 구조로 구현함.

### 2. 헤더 back 버튼 뒤로가기 로직 수정
기존엔 document.referrer로 내부/외부 진입을 구분했으나, 클라이언트 라우팅 후에도 referrer가 갱신되지 않는 문제가 있어 세션스토리지 기반 추적 방식으로 교체하는 과정에서, 세션 최초 진입 페이지에서도 마운트 즉시 "내부 이동 기록 있음"으로 잘못 표시되는 회귀가 있었음. 최초 진입과 실제 내부 이동을 구분하는 2단계 플래그로 수정

### 3. 작품 대표 이미지 비율 수정 (16:9)
- **이유** : 작품 이미지 클릭 시 상세보기 모달을 지원하므로, 초기 디자인대로 16:9 비율을 유지하는 것이 시각적으로 적절하다고 판단되어 초기 디자인으로 수정함.
- **현재 상태** : 작품 상세 페이지 진입 시 작품을 원본 크기대로 띄우지 않고, 16:9 비율에 맞게 잘라서 띄움(cover). 필요 시 이미지를 클릭하여 상세보기 모달을 볼 수 있음.
<img width="1277" height="659" alt="image" src="https://github.com/user-attachments/assets/8ee3c06e-fe08-4db9-a9c9-d72eeff4f8cb" />
<img width="286" height="611" alt="image" src="https://github.com/user-attachments/assets/c5e4cadd-7e1b-4abe-bd72-eda6f816ff5c" />


## 🖥️ 주요 코드 설명

`ImageViewerModal.tsx`

- 작품 이미지 상세보기 모달 컴포넌트입니다.
- 이 컴포넌트는 모바일뷰 디자인으로 구현되어있습니다. 
- 다음 두 지점에서 호출하여 사용합니다. (대표, 상세 이미지)
- 각 지점에서 handleImageClick을 작성하며 PC뷰 모달 구현해야 하는 부분 TODO로 주석 달아두었습니다

`ArtworkDetailClient.tsx`
```
	// 작품 대표 이미지 상세보기 모달 (모바일/데스크탑 분기처리)
	const handleMainImageClick = () => {
		if (window.matchMedia("(max-width: 720px)").matches) {
			setIsMainImageViewerOpen(true);
			return;
		}
		// TODO: PC 상세보기 모달 구현 예정
	};
```

`PhotoSection.tsx` 
```
const handleImageClick = (src: string, alt: string) => {
		if (window.matchMedia("(max-width: 720px)").matches) {
			setViewerImage({ src, alt });
			return;
		}
		// TODO: PC 상세보기 모달 구현 예정
	};
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #77 
