### PR TITLE
refactor: TrackedLink eventProps 함수형 지원 및 ExhibitionIntroSection 적용

### DIFF
--- a/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRef } from "react";
 import RowList from "@/components/common/RowList/RowList";
 import { Title } from "@/components/common/Title/Title";
+import { TrackedLink } from "@/components/common/TrackedLink";
 import { track } from "@/lib/amplitude";
 import type { ExhibitionDetail } from "@/lib/api/exhibition";
 import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
@@ -32,22 +33,20 @@ export function ExhibitionIntroSection({ exhibition, exhibitionId }: ExhibitionI
 		<section className="flex flex-col pb-6 pt-4 min-[721px]:pt-0" data-section="intro">
 			<Title title={exhibition.title} className="min-[721px]:mt-8 min-[721px]:mb-5" />
 			<RowList rows={rows} />
+			{/* 모바일 전용 CTA — 데스크탑은 page.tsx의 ExhibitionDetailSection 아래에 위치 */}
 			<div className="min-[721px]:hidden">
-				<Link href={`/${exhibitionId}/artwork`}>
-					<Button
-						variant="main"
-						className="w-full mt-7"
-						onClick={() => {
-							const elapsedSec = Math.round((Date.now() - entryTime.current) / 1000);
-							track("Exhibition CTA Clicked", {
-								exhibition_id: exhibitionId,
-								time_to_click_sec: elapsedSec,
-							});
-						}}
-					>
+				<TrackedLink
+					href={`/${exhibitionId}/artwork`}
+					eventName="Exhibition CTA Clicked"
+					eventProps={{
+						exhibition_id: exhibitionId,
+						time_to_click_sec: Math.round((Date.now() - entryTime.current) / 1000),
+					}}
+				>
+					<Button variant="main" className="w-full mt-7">
 						전시물 감상하기
 					</Button>
-				</Link>
+				</TrackedLink>
 			</div>
 		</section>
 	);

--- a/apps/client/app/[exhibitionId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/page.tsx
@@ -116,6 +116,7 @@ export default async function ExhibitionDetailPage({ params }: ExhibitionDetailP
 					<div className="flex flex-col min-[721px]:flex-1">
 						<ExhibitionIntroSection exhibition={exhibitionData} exhibitionId={exhibitionId} />
 						<ExhibitionDetailSection exhibition={exhibitionData} />
+						{/* 데스크탑 전용 CTA — ExhibitionDetailSection 아래 배치를 위해 page.tsx에서 분리 관리 */}
 						<div className="hidden min-[721px]:flex flex-col justify-center items-center pb-6 min-[721px]:items-start">
 							<TrackedLink
 								href={`/${exhibitionId}/artwork`}

--- a/apps/client/components/common/TrackedLink.tsx
+++ b/apps/client/components/common/TrackedLink.tsx
@@ -6,7 +6,7 @@ import { track } from "@/lib/amplitude";
 interface Props {
 	href: string;
 	eventName: string;
-	eventProps?: Record<string, unknown>;
+	eventProps?: Record<string, unknown> | (() => Record<string, unknown>);
 	className?: string;
 	children: React.ReactNode;
 	target?: string;
@@ -28,7 +28,7 @@ export function TrackedLink({
 			className={className}
 			target={target}
 			rel={rel}
-			onClick={() => track(eventName, eventProps)}
+			onClick={() => track(eventName, typeof eventProps === "function" ? eventProps() : eventProps)}
 		>
 			{children}
 		</Link>


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

- `TrackedLink`의 `eventProps` 타입을 함수형으로도 받을 수 있도록 확장
- `ExhibitionIntroSection`에서 직접 `track()`을 호출하던 방식을 `TrackedLink`로 교체

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

  `time_to_click_sec`처럼 클릭 시점에 계산해야 하는 값은 렌더 시점에 미리 계산하면 부정확합니다.
  -> `eventProps`를 함수로 전달하면 클릭 시점에 평가되어 정확한 값을 트래킹할 수 있습니다.


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`TrackedLink.tsx`

- eventProps를 함수로 전달하면 클릭 시점에 실행

```typescript
  onClick={() => track(eventName, typeof eventProps === "function" ?
  eventProps() : eventProps)}
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #이슈번호
