### PR TITLE
fix: kmu qa 버그 수정 및 전시 상세 ui 개선

### DIFF
--- a/apps/client/app/[exhibitionId]/_components/CopyAddressButton.tsx
+++ b/apps/client/app/[exhibitionId]/_components/CopyAddressButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+interface CopyAddressButtonProps {
+	address: string;
+}
+
+export function CopyAddressButton({ address }: CopyAddressButtonProps) {
+	const handleCopy = () => {
+		navigator.clipboard.writeText(address);
+		alert("주소가 복사되었습니다.");
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			className="text-body1 text-lightest underline text-left cursor-pointer"
+		>
+			주소 복사하기 →
+		</button>
+	);
+}

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
@@ -15,33 +15,39 @@ export function ExhibitionHostSection({ hostInfo, sns }: ExhibitionHostProps) {
 		<section className="flex flex-col pb-6" data-section="host">
 			<Title title="주최 기관" />
 
-			<div className="relative w-full aspect-video overflow-hidden">
-				{hostInfo.hostImageUrl ? (
-					<Image
-						src={hostInfo.hostImageUrl}
-						alt={hostInfo.hostName}
-						fill
-						className="object-cover"
-					/>
-				) : (
-					<EmptyImageFallback className="absolute inset-0" />
-				)}
-			</div>
-			<span className="text-body1-bold mt-5 mb-4">{hostInfo.hostName}</span>
-			<p className="text-body1 leading-relaxed mb-7 whitespace-pre-line">{hostInfo.description}</p>
-
-			{sns.length > 0 && (
-				<div className="flex flex-col gap-1">
-					{sns.map((link) => (
-						<SocialLink
-							key={link.snsId}
-							label={link.platformName}
-							href={link.url}
-							hostName={hostInfo.hostName}
+			<div className="flex flex-col min-[721px]:flex-row min-[721px]:gap-5">
+				<div className="relative w-full min-[721px]:w-[40%] min-[721px]:shrink-0 aspect-video overflow-hidden">
+					{hostInfo.hostImageUrl ? (
+						<Image
+							src={hostInfo.hostImageUrl}
+							alt={hostInfo.hostName}
+							fill
+							className="object-cover"
 						/>
-					))}
+					) : (
+						<EmptyImageFallback className="absolute inset-0" />
+					)}
 				</div>
-			)}
+				<div className="flex flex-col text-light">
+					<span className="text-body1-bold mt-5 min-[721px]:mt-0 mb-4">{hostInfo.hostName}</span>
+					<p className="text-body1 leading-relaxed mb-7 whitespace-pre-line">
+						{hostInfo.description}
+					</p>
+
+					{sns.length > 0 && (
+						<div className="flex flex-col gap-1">
+							{sns.map((link) => (
+								<SocialLink
+									key={link.snsId}
+									label={link.platformName}
+									href={link.url}
+									hostName={hostInfo.hostName}
+								/>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
 		</section>
 	);
 }
@@ -63,7 +69,7 @@ function SocialLink({ label, href }: SocialLinkProps) {
 
 	return (
 		<div className="flex flex-wrap items-center gap-1">
-			<span className="min-w-19 text-body2-bold shrink-0">{label}</span>
+			<span className="min-w-19 text-strong text-body2-bold shrink-0">{label}</span>
 			{resolvedHref ? (
 				<a
 					href={resolvedHref}

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { EmptyImageFallback } from "@/components/common/EmptyImageFallback/EmptyImageFallback";
 import { Title } from "@/components/common/Title/Title";
 import type { ExhibitionHost, HostSns } from "@/lib/api/exhibition";
+import { resolveSnsHref } from "@/lib/utils/sns";
 
 interface ExhibitionHostProps {
 	hostInfo: ExhibitionHost;
@@ -59,13 +60,7 @@ interface SocialLinkProps {
 }
 
 function SocialLink({ label, href }: SocialLinkProps) {
-	const isInstagram = label.toLowerCase() === "instagram";
-	const isUrl = href.startsWith("http://") || href.startsWith("https://");
-	const resolvedHref = isInstagram
-		? `https://www.instagram.com/${href.startsWith("@") ? href.slice(1) : href}/`
-		: isUrl
-			? href
-			: null;
+	const resolvedHref = resolveSnsHref(label, href);
 
 	return (
 		<div className="flex flex-wrap items-center gap-1">

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionHostSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Image from "next/image";
-import { EmptyImageFallback } from "@/components/common/EmptyImageFallback/EmptyImageFallback";
 import { Title } from "@/components/common/Title/Title";
 import type { ExhibitionHost, HostSns } from "@/lib/api/exhibition";
 import { resolveSnsHref } from "@/lib/utils/sns";
@@ -17,18 +16,16 @@ export function ExhibitionHostSection({ hostInfo, sns }: ExhibitionHostProps) {
 			<Title title="주최 기관" />
 
 			<div className="flex flex-col min-[721px]:flex-row min-[721px]:gap-5">
-				<div className="relative w-full min-[721px]:w-[40%] min-[721px]:shrink-0 aspect-video overflow-hidden">
-					{hostInfo.hostImageUrl ? (
+				{hostInfo.hostImageUrl && (
+					<div className="relative w-full min-[721px]:w-[40%] min-[721px]:shrink-0 aspect-video overflow-hidden">
 						<Image
 							src={hostInfo.hostImageUrl}
 							alt={hostInfo.hostName}
 							fill
 							className="object-cover"
 						/>
-					) : (
-						<EmptyImageFallback className="absolute inset-0" />
-					)}
-				</div>
+					</div>
+				)}
 				<div className="flex flex-col text-light">
 					<span className="text-body1-bold mt-5 min-[721px]:mt-0 mb-4">{hostInfo.hostName}</span>
 					<p className="text-body1 leading-relaxed mb-7 whitespace-pre-line">

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionIntroSection.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { Button } from "components";
-import Link from "next/link";
 import { useRef } from "react";
 import RowList from "@/components/common/RowList/RowList";
 import { Title } from "@/components/common/Title/Title";
 import { TrackedLink } from "@/components/common/TrackedLink";
-import { track } from "@/lib/amplitude";
 import type { ExhibitionDetail } from "@/lib/api/exhibition";
 import { EXHIBITION_TYPE_LABEL } from "@/lib/constants/exhibition";
 

--- a/apps/client/app/[exhibitionId]/_components/ExhibitionLocationSection.tsx
+++ b/apps/client/app/[exhibitionId]/_components/ExhibitionLocationSection.tsx
@@ -1,5 +1,6 @@
 import { Title } from "@/components/common/Title/Title";
 import type { ExhibitionLocation } from "@/lib/api/exhibition";
+import { CopyAddressButton } from "./CopyAddressButton";
 import { LocationMap } from "./LocationMap";
 
 interface ExhibitionLocationProps {
@@ -10,12 +11,32 @@ export function ExhibitionLocationSection({ location }: ExhibitionLocationProps)
 	return (
 		<section className="flex flex-col pb-6" data-section="location">
 			<Title title="장소" />
-			<LocationMap address={location.address} lat={location.latitude} lng={location.longitude} />
-			<p className="text-body1">{location.address}</p>
-			{location.detail_location && <p className="text-body1">{location.detail_location}</p>}
-			{location.location_description && (
-				<p className="text-body1">{location.location_description}</p>
-			)}
+			<div className="flex flex-col min-[721px]:flex-row min-[721px]:gap-5">
+				<div className="min-[721px]:w-[40%] min-[721px]:shrink-0">
+					<LocationMap
+						address={location.address}
+						lat={location.latitude}
+						lng={location.longitude}
+					/>
+				</div>
+				{/* 모바일: 지도 아래에 주소 텍스트 */}
+				<div className="flex flex-col gap-1 min-[721px]:hidden">
+					<p className="text-body1">{location.address}</p>
+					{location.detail_location && <p className="text-body1">{location.detail_location}</p>}
+					{location.location_description && (
+						<p className="text-body1">{location.location_description}</p>
+					)}
+				</div>
+				{/* 데스크탑: 지도 오른쪽에 주소 텍스트 + 복사 버튼 */}
+				<div className="hidden min-[721px]:flex flex-col gap-7 text-body1 text-light">
+					<div className="flex flex-col">
+						<p>{location.address}</p>
+						{location.detail_location && <p>{location.detail_location}</p>}
+						{location.location_description && <p>{location.location_description}</p>}
+					</div>
+					<CopyAddressButton address={location.address} />
+				</div>
+			</div>
 		</section>
 	);
 }

--- a/apps/client/app/[exhibitionId]/_components/LocationMap.tsx
+++ b/apps/client/app/[exhibitionId]/_components/LocationMap.tsx
@@ -27,6 +27,8 @@ export function LocationMap({ address, lat, lng }: LocationMapProps) {
 					지도를 불러오지 못했습니다
 				</div>
 			) : (
+				// biome-ignore lint/performance/noImgElement: onError로 지도 로드 실패를 감지해야 하므로 img 사용
+				// biome-ignore lint/a11y/noNoninteractiveElementInteractions: onError 핸들러가 필요함
 				<img
 					src={`/api/map-image?lat=${lat}&lng=${lng}`}
 					alt={address}
@@ -36,7 +38,7 @@ export function LocationMap({ address, lat, lng }: LocationMapProps) {
 			)}
 
 			{/* 하단 버튼바 컨테이너 */}
-			<div className="flex items-center p-3 bg-fg-lighter rounded-b-[10px]">
+			<div className="min-[721px]:hidden flex items-center p-3 bg-fg-lighter rounded-b-[10px]">
 				{/* 네이버 맵 버튼 */}
 				<a
 					href={naverMapSearchUrl}
@@ -54,7 +56,7 @@ export function LocationMap({ address, lat, lng }: LocationMapProps) {
 					<span className="px-1.25 text-body2-bold text-lighter">네이버 맵</span>
 				</a>
 
-				<div className="w-[1px] h-4 border border-stroke-lighter" />
+				<div className="w-px h-4 border border-stroke-lighter" />
 
 				{/* 카카오 맵 버튼 */}
 				<a
@@ -73,10 +75,11 @@ export function LocationMap({ address, lat, lng }: LocationMapProps) {
 					<span className="px-1 text-body2-bold text-lighter">카카오 맵</span>
 				</a>
 
-				<div className="w-[1px] h-4 border border-stroke-lighter" />
+				<div className="w-px h-4 border border-stroke-lighter" />
 
 				{/* 주소 복사 버튼 */}
 				<button
+					type="button"
 					onClick={handleCopyAddress}
 					className="flex-1 flex items-center justify-center gap-0.5 cursor-pointer"
 				>

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtistCard.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtistCard.tsx
@@ -7,6 +7,7 @@ import { EmptyArtistIcon } from "@/components/common/icons/EmptyArtistIcon";
 import RowList from "@/components/common/RowList/RowList";
 import { track } from "@/lib/amplitude";
 import type { ArtworkParticipant } from "@/lib/api/artwork";
+import { resolveSnsHref } from "@/lib/utils/sns";
 
 export interface ArtistCardProps {
 	author: ArtworkParticipant;
@@ -39,13 +40,7 @@ export function ArtistCard({ author, profileHref }: ArtistCardProps) {
 							]
 						: []),
 					...(author.sns ?? []).map((sns) => {
-						const isInstagram = sns.platformName.toLowerCase() === "instagram";
-						const isUrl = sns.url.startsWith("http://") || sns.url.startsWith("https://");
-						const href = isInstagram
-							? `https://www.instagram.com/${sns.url.startsWith("@") ? sns.url.slice(1) : sns.url}/`
-							: isUrl
-								? sns.url
-								: null;
+						const href = resolveSnsHref(sns.platformName, sns.url);
 						return {
 							label: sns.platformName,
 							value: href ? (

--- a/apps/client/app/[exhibitionId]/bts/[btsId]/_components/BtsDetailClient.tsx
+++ b/apps/client/app/[exhibitionId]/bts/[btsId]/_components/BtsDetailClient.tsx
@@ -45,7 +45,8 @@ export function BtsDetailClient({ btsItem, exhibitionId }: BtsDetailClientProps)
 		id: a.artworkId,
 		title: a.title,
 		imageUrl: a.image ?? undefined,
-		author: "",
+		category: a.category ?? undefined,
+		author: (a.artistNames ?? []).join(", "),
 	}));
 
 	return (
@@ -159,7 +160,12 @@ export function BtsDetailClient({ btsItem, exhibitionId }: BtsDetailClientProps)
 					<DesktopContainer>
 						<section ref={setRelatedRef} className="pb-6">
 							<Title title="연관 작품" size="head2" className="mt-4 mb-4" />
-							<CardGrid items={relatedArtworkItems} limit={3} className="min-[721px]:grid-cols-2" />
+							<CardGrid
+								items={relatedArtworkItems}
+								limit={3}
+								className="min-[721px]:grid-cols-2"
+								getHref={(item) => `/${exhibitionId}/artwork/${item.id}`}
+							/>
 						</section>
 					</DesktopContainer>
 				</>

--- a/apps/client/app/[exhibitionId]/layout.tsx
+++ b/apps/client/app/[exhibitionId]/layout.tsx
@@ -94,6 +94,7 @@ export default async function ExhibitionLayout({
 	};
 
 	const footer = uuid ? await getExhibitionFooter(uuid) : null;
+	// console.log("[ExhibitionFooter]", JSON.stringify(footer, null, 2));
 
 	const colorVars = {
 		...(config.btnBg && { "--btn-bg": config.btnBg }),
@@ -121,10 +122,10 @@ export default async function ExhibitionLayout({
 
 					{footer ? (
 						<SchoolFooter
-							logoSrc={config.footerInfo.logoSrc}
 							title={footer.title}
 							department={footer.department}
 							address={footer.address ?? ""}
+							univ_name={footer.univ_name ?? ""}
 							detail_location={footer.detail_location ?? ""}
 							email={footer.email}
 							copyright={footer.copyright ?? ""}

--- a/apps/client/app/[exhibitionId]/page.tsx
+++ b/apps/client/app/[exhibitionId]/page.tsx
@@ -99,7 +99,7 @@ export default async function ExhibitionDetailPage({ params }: ExhibitionDetailP
 				{/* 대표 이미지 + 제목/기본 정보 + 전시 소개: 데스크탑에서 flex row */}
 				<div className="flex flex-col min-[721px]:flex-row min-[721px]:items-start min-[721px]:gap-5">
 					{/* 이미지: 모바일 full-width, 데스크탑 fixed width */}
-					<div className="relative -mx-4 w-[calc(100%+2rem)] aspect-[1/1.414] min-[721px]:mx-0 min-[721px]:w-[30%] min-[721px]:shrink-0 min-[721px]:mt-8 overflow-hidden">
+					<div className="relative -mx-4 w-[calc(100%+2rem)] aspect-157/222 min-[721px]:mx-0 min-[721px]:w-[45%] min-[721px]:shrink-0 min-[721px]:mt-8 overflow-hidden">
 						{exhibitionData.exhibitionImg ? (
 							<Image
 								src={exhibitionData.exhibitionImg}

--- a/apps/client/components/common/Card/LinkCard/LinkCard.tsx
+++ b/apps/client/components/common/Card/LinkCard/LinkCard.tsx
@@ -1,3 +1,4 @@
+import { resolveSnsHref } from "@/lib/utils/sns";
 import { linkCardStyles as s } from "./LinkCard.styles";
 import type { LinkCardProps } from "./LinkCard.types";
 
@@ -10,11 +11,7 @@ export const LinkCard = ({ items, className, onItemClick }: LinkCardProps) => {
 
 	const getHref = (item: LinkCardProps["items"][number]) => {
 		if (item.type === "email") return `mailto:${item.value}`;
-		if (item.label.toLowerCase() === "instagram") {
-			const username = item.value.startsWith("@") ? item.value.slice(1) : item.value;
-			return `https://www.instagram.com/${username}/`;
-		}
-		if (item.type === "url") return item.value;
+		if (item.type === "url") return resolveSnsHref(item.label, item.value);
 		return null;
 	};
 

--- a/apps/client/components/common/Footer/SchoolFooter.tsx
+++ b/apps/client/components/common/Footer/SchoolFooter.tsx
@@ -1,32 +1,25 @@
 import Image from "next/image";
 import { DesktopContainer } from "@/components/common/DesktopContainer/DesktopContainer";
-
-interface SchoolFooterProps {
-	logoSrc?: string;
-	title: string;
-	department: string;
-	address: string;
-	detail_location: string; //상세 주소
-	email: string;
-	copyright: string;
-}
+import type { ExhibitionFooter } from "@/lib/api/layout.types";
 
 export default function SchoolFooter({
-	logoSrc,
 	title,
 	department,
 	address,
+	univ_name,
 	detail_location,
 	email,
 	copyright,
-}: SchoolFooterProps) {
+}: ExhibitionFooter) {
 	return (
 		<footer className="w-full pb-20 flex flex-col mt-12 bg-fg-lighter">
 			<DesktopContainer className="flex pt-6 flex-col">
 				<div className="flex flex-col gap-1">
 					<h3 className="text-body1-bold text-light">{title}</h3>
 					<div className="h-5 w-full" />
-					<p className="text-body2 text-lighter">{department}</p>
+					<p className="text-body2 text-lighter">
+						{univ_name} {department}
+					</p>
 					<div>
 						<p className="text-body2 text-lighter">{address}</p>
 						<p className="text-body2 text-lighter">{detail_location}</p>

--- a/apps/client/lib/api/bts.types.ts
+++ b/apps/client/lib/api/bts.types.ts
@@ -37,6 +37,8 @@ export interface BtsRelatedArtwork {
 	artworkId: string;
 	title: string;
 	image: string | null;
+	category: string | null;
+	artistNames: string[] | null;
 }
 
 export interface BtsRecommendedItem {

--- a/apps/client/lib/api/layout.types.ts
+++ b/apps/client/lib/api/layout.types.ts
@@ -2,6 +2,7 @@ export interface ExhibitionFooter {
 	title: string;
 	department: string;
 	address: string | null;
+	univ_name: string | null;
 	detail_location: string | null;
 	email: string;
 	copyright: string | null;

--- a/apps/client/lib/utils/sns.ts
+++ b/apps/client/lib/utils/sns.ts
@@ -1,0 +1,10 @@
+export function resolveSnsHref(platformName: string, url: string): string | null {
+	const isInstagram = platformName.toLowerCase() === "instagram" || platformName === "인스타그램";
+	const isUrl = url.startsWith("http://") || url.startsWith("https://");
+
+	if (isInstagram) {
+		return `https://instagram.com/${url.startsWith("@") ? url.slice(1) : url}/`;
+	}
+	if (isUrl) return url;
+	return null;
+}


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

  - SNS href 변환 로직을 `resolveSnsHref()` 공통 유틸로 추출 (`lib/utils/sns.ts`)                                                        
  - BTS 상세 페이지 연관 작품 클릭 시 이동 안 되던 버그 수정
  - BTS 연관 작품에 카테고리, 작가명 노출                                     
  - 전시 footer에 학교명(`univ_name`) 필드 추가
  - 전시 메인 이미지 비율 `157:222`로 변경                                    
  - 전시 소개 장소/주최기관 섹션 데스크탑 2열 레이아웃 적용                   
  - 주최기관 이미지 없을 경우 이미지 영역 렌더링 제거

## 💡 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
   
  - `resolveSnsHref()`는 `"instagram"` / `"인스타그램"` 모두 처리하며 `ExhibitionHostSection`, `ArtistCard`, `LinkCard` 세 곳에 적용됩니다.

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`resolveSnsHref`

- SNS 링크 변환 유틸
- 기존에 `ExhibitionHostSection`, `ArtistCard`, `LinkCard` 각각에 인라인으로 중복 구현되어 있던 인스타그램 URL 변환 로직을 공통 유틸로 추출
- `"instagram"`, `"인스타그램"` 모두 처리하도록 개선 (한글 플랫폼명일 때 로컬 경로로 이동하던 버그 수정)

```typescript
  export function resolveSnsHref(platformName: string, url: string): string | 
  null {                                      
      const isInstagram =                                                     
          platformName.toLowerCase() === "instagram" || platformName ===
  "인스타그램";                                                               
                                          
      if (isInstagram) {                                                      
          return `https://instagram.com/${url.startsWith("@") ? url.slice(1) :
   url}/`;                                    
      }                                                                       
      if (url.startsWith("http://") || url.startsWith("https://")) return url;
      return null;                                                            
  } 
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #132
