### PR TITLE
fix: 작품 섹션 조건부 렌더링, 작품 대표 이미지 비율 수정

### DIFF
--- a/apps/client/app/(main)/_components/ExhibitionCard.tsx
+++ b/apps/client/app/(main)/_components/ExhibitionCard.tsx
@@ -14,10 +14,15 @@ export default function ExhibitionCard({
 	endDate,
 }: Omit<ExhibitionItem, "id">) {
 	return (
-		<article className="flex gap-4 min-[721px]:flex-col min-[721px]:gap-3">
+		<article className="group flex gap-4 min-[721px]:flex-col min-[721px]:gap-3">
 			<div className="relative self-stretch h-40 aspect-[1/1.414] shrink-0 overflow-hidden min-[721px]:h-auto min-[721px]:w-full">
 				{imageUrl ? (
-					<Image src={imageUrl} alt={title} fill className="object-cover" />
+					<Image
+						src={imageUrl}
+						alt={title}
+						fill
+						className="object-cover transition-transform duration-300 group-hover:scale-105"
+					/>
 				) : (
 					<EmptyImageFallback className="absolute inset-0" />
 				)}

--- a/apps/client/app/[exhibitionId]/artist/[artistId]/_components/sections/ArtworkSection.tsx
+++ b/apps/client/app/[exhibitionId]/artist/[artistId]/_components/sections/ArtworkSection.tsx
@@ -12,6 +12,8 @@ export function ArtworkSection({
 	artist: ArtistDetail;
 	exhibitionId: string;
 }) {
+	if (!artist.artworks.length) return null;
+
 	const items = artist.artworks.map((a) => ({
 		id: a.artworkId,
 		title: a.title,

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
@@ -62,21 +62,39 @@ export function ArtworkDetailClient({
 
 			<div className="w-full">
 				{data.mainImage ? (
-					<button
-						type="button"
-						onClick={handleMainImageClick}
-						className="relative block w-full aspect-video cursor-pointer overflow-hidden min-[721px]:max-h-[400px]"
-						aria-label="작품 대표 이미지 전체보기"
-					>
-						<Image
-							src={data.mainImage}
-							alt={data.title}
-							fill
-							sizes="100vw"
-							className="object-cover"
-							priority
-						/>
-					</button>
+					<>
+						<button
+							type="button"
+							onClick={handleMainImageClick}
+							className="relative block w-full cursor-pointer overflow-hidden min-[721px]:hidden"
+							aria-label="작품 대표 이미지 전체보기"
+						>
+							<Image
+								src={data.mainImage}
+								alt={data.title}
+								width={0}
+								height={0}
+								sizes="100vw"
+								style={{ width: "100%", height: "auto" }}
+								priority
+							/>
+						</button>
+						<button
+							type="button"
+							onClick={handleMainImageClick}
+							className="relative hidden w-full cursor-pointer overflow-hidden min-[721px]:block min-[721px]:aspect-video min-[721px]:max-h-[400px]"
+							aria-label="작품 대표 이미지 전체보기"
+						>
+							<Image
+								src={data.mainImage}
+								alt={data.title}
+								fill
+								sizes="100vw"
+								className="object-cover"
+								priority
+							/>
+						</button>
+					</>
 				) : (
 					<EmptyImageFallback className="w-full aspect-video min-[721px]:max-h-[400px]" />
 				)}

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
@@ -82,15 +82,16 @@ export function ArtworkDetailClient({
 						<button
 							type="button"
 							onClick={handleMainImageClick}
-							className="relative hidden w-full cursor-pointer overflow-hidden min-[721px]:block min-[721px]:aspect-video min-[721px]:max-h-[400px]"
+							className="relative hidden w-full cursor-pointer overflow-hidden min-[721px]:flex min-[721px]:items-center min-[721px]:justify-center"
 							aria-label="작품 대표 이미지 전체보기"
 						>
 							<Image
 								src={data.mainImage}
 								alt={data.title}
-								fill
+								width={0}
+								height={0}
 								sizes="100vw"
-								className="object-cover"
+								style={{ width: "auto", height: "auto", maxWidth: "100%", maxHeight: "400px" }}
 								priority
 							/>
 						</button>

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/RelatedSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/RelatedSection.tsx
@@ -28,7 +28,6 @@ export const RelatedSection = ({ artworks, artworkTitle }: RelatedSectionProps) 
 					items={items}
 					getHref={(item) => `${item.id}`}
 					limit={2}
-					disableHover
 					onItemClick={(item) =>
 						track("Related Artwork Clicked", {
 							clicked_artwork_id: item.id,

--- a/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/_components/ArtworkListSection.tsx
@@ -162,7 +162,9 @@ export function ArtworkListSection({
 								>
 									{isMultiZone && <Title title={zone.zoneName} />}
 									{isMultiZone && zone.description && (
-										<p className="text-body2 text-light mb-4 whitespace-pre-wrap">{zone.description}</p>
+										<p className="text-body2 text-light mb-4 whitespace-pre-wrap">
+											{zone.description}
+										</p>
 									)}
 									{viewMode === "grid" ? (
 										<CardGrid


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

### 1. [작품 상세 페이지] (모바일뷰+PC뷰) 작품 대표 이미지 비율 원본 유지
<img width="239" height="627" alt="image" src="https://github.com/user-attachments/assets/88aa4b44-c5dc-4659-b57a-d2089c122429" />
<img width="991" height="554" alt="image" src="https://github.com/user-attachments/assets/5ffe9c5a-10e9-43b0-a0c4-125ab4af5aa8" />

### 2. [작가 상세 페이지] 작품 데이터 없을 경우 섹션 숨김 (조건부 렌더링)
<img width="401" height="620" alt="image" src="https://github.com/user-attachments/assets/b7d3b46d-6670-4b2f-9926-96bd1c49a05e" />

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #이슈번호
