### PR TITLE
feat: 작품 이미지 데스크탑 뷰어 모달 구현 + 참여한 사람들 2열 레이아웃

### DIFF
--- a/apps/client/app/(main)/_components/CategorySection.tsx
+++ b/apps/client/app/(main)/_components/CategorySection.tsx
@@ -56,6 +56,7 @@ export default function CategorySection({ title, categories, artworks, slugMap }
 							page: "main",
 						})
 					}
+					imageObjectFit="contain"
 				/>
 			</div>
 

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/ArtworkDetailClient.tsx
@@ -47,13 +47,8 @@ export function ArtworkDetailClient({
 
 	const [isMainImageViewerOpen, setIsMainImageViewerOpen] = useState(false);
 
-	// 작품 대표 이미지 상세보기 모달 (모바일/데스크탑 분기처리)
 	const handleMainImageClick = () => {
-		if (window.matchMedia("(max-width: 720px)").matches) {
-			setIsMainImageViewerOpen(true);
-			return;
-		}
-		// TODO: PC 상세보기 모달 구현 예정
+		setIsMainImageViewerOpen(true);
 	};
 
 	return (

--- a/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/PhotoSection.tsx
+++ b/apps/client/app/[exhibitionId]/artwork/[artworkId]/_components/PhotoSection.tsx
@@ -20,13 +20,8 @@ export const PhotoSection = ({ data }: PhotoSectionProps) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [viewerImage, setViewerImage] = useState<{ src: string; alt: string } | null>(null);
 
-	// 작품 상세 이미지 상세보기 모달 (모바일/데스크탑 분기처리)
 	const handleImageClick = (src: string, alt: string) => {
-		if (window.matchMedia("(max-width: 720px)").matches) {
-			setViewerImage({ src, alt });
-			return;
-		}
-		// TODO: PC 상세보기 모달 구현 예정
+		setViewerImage({ src, alt });
 	};
 	const { purchaseUrl } = data;
 

--- a/apps/client/components/common/Card/Card.styles.ts
+++ b/apps/client/components/common/Card/Card.styles.ts
@@ -2,7 +2,7 @@ export const cardStyles = {
 	wrapper: "w-full flex flex-col items-start gap-[12px]",
 	wrapperHover: "group",
 	imageWrapper: "relative w-full aspect-[1/1.414] overflow-hidden ",
-	image: "w-full h-full object-cover transition-transform duration-300 group-hover:scale-105",
+	image: "w-full h-full transition-transform duration-300 group-hover:scale-105",
 	info: "w-full flex flex-col gap-[4px]",
 	title: "text-strong text-head3 break-all",
 	category: "text-light text-body2",

--- a/apps/client/components/common/Card/Card.tsx
+++ b/apps/client/components/common/Card/Card.tsx
@@ -12,7 +12,13 @@ export const Card = ({
 	emptyIcon,
 	onClick,
 	disableHover,
-}: CardProps & { href?: string; onClick?: () => void; disableHover?: boolean }) => {
+	imageObjectFit = "cover",
+}: CardProps & {
+	href?: string;
+	onClick?: () => void;
+	disableHover?: boolean;
+	imageObjectFit?: "cover" | "contain";
+}) => {
 	const content = (
 		<article className={`${s.wrapper}${disableHover ? "" : ` ${s.wrapperHover}`}`}>
 			<div className={s.imageWrapper}>
@@ -23,7 +29,7 @@ export const Card = ({
 						width={0}
 						height={0}
 						sizes="100vw"
-						className={s.image}
+						className={`${s.image} ${imageObjectFit === "contain" ? "object-contain" : "object-cover"}`}
 						loading="lazy"
 					/>
 				) : (

--- a/apps/client/components/common/Card/Card.types.ts
+++ b/apps/client/components/common/Card/Card.types.ts
@@ -22,4 +22,5 @@ export interface CardGridProps {
 	onItemClick?: (item: CardItem) => void;
 	className?: string;
 	disableHover?: boolean;
+	imageObjectFit?: "cover" | "contain";
 }

--- a/apps/client/components/common/Card/CardGrid.tsx
+++ b/apps/client/components/common/Card/CardGrid.tsx
@@ -8,6 +8,7 @@ export const CardGrid = ({
 	onItemClick,
 	className,
 	disableHover,
+	imageObjectFit,
 }: CardGridProps) => {
 	const displayedItems = limit ? items.slice(0, limit) : items;
 
@@ -22,6 +23,7 @@ export const CardGrid = ({
 					href={getHref?.(item)}
 					onClick={onItemClick ? () => onItemClick(item) : undefined}
 					disableHover={disableHover}
+					imageObjectFit={imageObjectFit}
 				/>
 			))}
 		</div>

--- a/apps/client/components/common/Card/RowCard/RowCard.tsx
+++ b/apps/client/components/common/Card/RowCard/RowCard.tsx
@@ -5,23 +5,25 @@ import { EmptyImageFallback } from "../../EmptyImageFallback/EmptyImageFallback"
 import { rowCardStyles as s } from "./RowCard.styles";
 import type { RowCardProps } from "./RowCard.types";
 
-export const RowCard = ({ name, engName, email, imageUrl }: RowCardProps) => {
+export const RowCard = ({ name, engName, email, imageUrl, showImage = true }: RowCardProps) => {
 	return (
-		<article className={s.wrapper}>
-			<div className={s.imageWrapper}>
-				{imageUrl ? (
-					<Image
-						src={imageUrl}
-						alt={`${name} ${engName}`}
-						width={72}
-						height={96}
-						className={s.image}
-						unoptimized
-					/>
-				) : (
-					<EmptyImageFallback className="w-full h-full" />
-				)}
-			</div>
+		<article className={`${s.wrapper} ${!showImage ? "pb-4 border-b border-stroke-lighter" : ""}`}>
+			{showImage && (
+				<div className={s.imageWrapper}>
+					{imageUrl ? (
+						<Image
+							src={imageUrl}
+							alt={`${name} ${engName}`}
+							width={72}
+							height={96}
+							className={s.image}
+							unoptimized
+						/>
+					) : (
+						<EmptyImageFallback className="w-full h-full" />
+					)}
+				</div>
+			)}
 
 			{/* 텍스트 */}
 			<section className={s.info}>

--- a/apps/client/components/common/Card/RowCard/RowCard.types.ts
+++ b/apps/client/components/common/Card/RowCard/RowCard.types.ts
@@ -6,7 +6,9 @@ export interface RowCardItem {
 	imageUrl?: string;
 }
 
-export interface RowCardProps extends Omit<RowCardItem, "id"> {}
+export interface RowCardProps extends Omit<RowCardItem, "id"> {
+	showImage?: boolean;
+}
 
 export interface RowCardGridProps {
 	items: RowCardItem[];

--- a/apps/client/components/common/Card/RowCard/RowCardGrid.tsx
+++ b/apps/client/components/common/Card/RowCard/RowCardGrid.tsx
@@ -3,11 +3,12 @@ import type { RowCardGridProps } from "./RowCard.types";
 
 export const RowCardGrid = ({ items = [], limit }: RowCardGridProps) => {
 	const displayedItems = limit ? items.slice(0, limit) : items;
+	const showImage = items.some((item) => item.imageUrl);
 
 	return (
-		<div className="flex flex-col gap-4 w-full">
+		<div className="flex flex-col gap-4 w-full min-[721px]:grid min-[721px]:grid-cols-2 min-[721px]:[row-gap:var(--grid-flex,30px)] min-[721px]:[column-gap:var(--grid-col-gap,20px)]">
 			{displayedItems.map((item) => (
-				<RowCard key={item.id} {...item} />
+				<RowCard key={item.id} {...item} showImage={showImage} />
 			))}
 		</div>
 	);

--- a/apps/client/components/common/ImageViewerModal/ImageViewerModal.styles.ts
+++ b/apps/client/components/common/ImageViewerModal/ImageViewerModal.styles.ts
@@ -1,5 +1,6 @@
 export const imageViewerModalStyles = {
-	overlay: "fixed inset-0 bg-bg-normal z-[100] animate-in fade-in duration-200",
+	overlay:
+		"fixed inset-0 bg-bg-normal min-[721px]:bg-black/80 z-[100] animate-in fade-in duration-200",
 
 	content: "fixed inset-0 z-[101] flex flex-col outline-none animate-in fade-in duration-200",
 
@@ -10,10 +11,13 @@ export const imageViewerModalStyles = {
 	transformContent:
 		"!w-full !h-full flex items-center justify-center transform-gpu backface-hidden",
 
-	image: "max-w-full max-h-full object-contain select-none",
+	image: "max-w-full max-h-full min-[721px]:max-w-[calc(100vw-160px)] object-contain select-none",
 
-	zoomControls: "absolute bottom-6 right-4 z-10 flex flex-col gap-2",
+	zoomControls: "absolute bottom-6 right-4 z-10 flex flex-col gap-2 min-[721px]:hidden",
 
 	zoomButton:
 		"p-2 rounded-full bg-white/90 cursor-pointer active:scale-95 transition-transform disabled:opacity-40 disabled:cursor-default",
+
+	desktopCloseButton:
+		"hidden min-[721px]:flex fixed z-[102] items-center justify-center w-9 h-9 rounded-full bg-[#F7F7F8] cursor-pointer hover:bg-white transition-colors",
 };

--- a/apps/client/components/common/ImageViewerModal/ImageViewerModal.tsx
+++ b/apps/client/components/common/ImageViewerModal/ImageViewerModal.tsx
@@ -2,9 +2,10 @@
 
 import * as Dialog from "@radix-ui/react-dialog";
 import Image from "next/image";
+import { useCallback, useRef, useState } from "react";
 import { TransformComponent, TransformWrapper, useControls } from "react-zoom-pan-pinch";
 import { Header } from "@/app/[exhibitionId]/_components/Header";
-import { imageViewerModalStyles } from "./ImageViewerModal.styles";
+import { imageViewerModalStyles as s } from "./ImageViewerModal.styles";
 
 interface ImageViewerModalProps {
 	open: boolean;
@@ -18,21 +19,11 @@ function ZoomControls() {
 	const { zoomIn, zoomOut } = useControls();
 
 	return (
-		<div className={imageViewerModalStyles.zoomControls}>
-			<button
-				type="button"
-				onClick={() => zoomIn()}
-				className={imageViewerModalStyles.zoomButton}
-				aria-label="확대"
-			>
+		<div className={s.zoomControls}>
+			<button type="button" onClick={() => zoomIn()} className={s.zoomButton} aria-label="확대">
 				<Image src="/icons/zoomIn.svg" alt="확대" width={24} height={24} />
 			</button>
-			<button
-				type="button"
-				onClick={() => zoomOut()}
-				className={imageViewerModalStyles.zoomButton}
-				aria-label="축소"
-			>
+			<button type="button" onClick={() => zoomOut()} className={s.zoomButton} aria-label="축소">
 				<Image src="/icons/zoomOut.svg" alt="축소" width={24} height={24} />
 			</button>
 		</div>
@@ -46,29 +37,66 @@ export const ImageViewerModal = ({
 	alt,
 	title,
 }: ImageViewerModalProps) => {
+	const imgRef = useRef<HTMLImageElement>(null);
+	const [closePos, setClosePos] = useState({ top: 20, right: 20 });
+	const isDesktop = typeof window !== "undefined" && window.innerWidth >= 721;
+
+	const updateClosePos = useCallback(() => {
+		requestAnimationFrame(() => {
+			const el = imgRef.current;
+			if (!el) return;
+			const rect = el.getBoundingClientRect();
+			if (rect.width === 0 || rect.height === 0) return;
+			const vw = window.innerWidth;
+			setClosePos({
+				top: Math.max(20, rect.top + 20),
+				right: Math.max(20, vw - rect.right + 20),
+			});
+		});
+	}, []);
+
 	return (
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
 			<Dialog.Portal>
-				<Dialog.Overlay className={imageViewerModalStyles.overlay} />
-				<Dialog.Content
-					className={imageViewerModalStyles.content}
-					onOpenAutoFocus={(e) => e.preventDefault()}
-				>
+				<Dialog.Overlay className={s.overlay} />
+				<Dialog.Content className={s.content} onOpenAutoFocus={(e) => e.preventDefault()}>
 					<Dialog.Title className="sr-only">{alt}</Dialog.Title>
-					<Header
-						variant="back"
-						title={title}
-						onBackClick={() => onOpenChange(false)}
-						showHamburger={false}
-					/>
-					<div className={imageViewerModalStyles.imageArea}>
-						<TransformWrapper doubleClick={{ mode: "toggle" }} wheel={{ disabled: true }}>
+
+					{/* 모바일: 상단 뒤로가기 헤더 */}
+					<div className="min-[721px]:hidden">
+						<Header
+							variant="back"
+							title={title}
+							onBackClick={() => onOpenChange(false)}
+							showHamburger={false}
+						/>
+					</div>
+
+					{/* 데스크탑: 이미지 우상단 닫기 버튼 */}
+					<button
+						type="button"
+						onClick={() => onOpenChange(false)}
+						style={{ top: closePos.top, right: closePos.right }}
+						className={s.desktopCloseButton}
+						aria-label="닫기"
+					>
+						<Image src="/icons/close.svg" alt="닫기" width={20} height={20} />
+					</button>
+
+					<div className={s.imageArea}>
+						<TransformWrapper
+							doubleClick={{ mode: "toggle" }}
+							wheel={{ disabled: !isDesktop }}
+							minScale={0.5}
+							centerZoomedOut
+							onTransform={updateClosePos}
+						>
 							<TransformComponent
-								wrapperClass={imageViewerModalStyles.transformWrapper}
-								contentClass={imageViewerModalStyles.transformContent}
+								wrapperClass={s.transformWrapper}
+								contentClass={s.transformContent}
 							>
 								{/* biome-ignore lint/performance/noImgElement: react-zoom-pan-pinch가 순수 img 요소에 transform을 적용해야 함 */}
-								<img src={src} alt={alt} className={imageViewerModalStyles.image} />
+								<img ref={imgRef} src={src} alt={alt} className={s.image} onLoad={updateClosePos} />
 							</TransformComponent>
 							<ZoomControls />
 						</TransformWrapper>


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

  1. ImageViewerModal 데스크탑 버전 구현  
  - 마우스 휠 스크롤 확대/축소
  - 축소 시 이미지 중앙 고정 (centerZoomedOut)     
                                                                        
  2. 작품 이미지 클릭 PC 대응 (TODO 처리)
                                                                        
  - ArtworkDetailClient.tsx - 대표 이미지 클릭 시 모바일/데스크탑 구분 없이 뷰어 모달 오픈
  - PhotoSection.tsx -상세 이미지 클릭 동일 처리
                                                                        
  3. 도움을 주신 분들 데스크탑 레이아웃       
  - RowCardGrid: 데스크탑에서 2열 그리드 적용                                       
  - 파트 내 멤버 전원 이미지 없을 시 이미지 영역 제거      
  - 파트 내 한 명이라도 이미지 있으면 기존대로 빈 placeholder 유지

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`ImageViewerModal`

- 모바일/데스크탑 반응형 분기

```typescript
  // 모바일: Header + 뒤로가기 (min-[721px]:hidden)                     
  // 데스크탑: 다크 오버레이 + X 버튼 위치 동적 계산
  const updateClosePos = useCallback(() => {                            
    requestAnimationFrame(() => {             
      const rect = imgRef.current?.getBoundingClientRect();             
      if (!rect || rect.width === 0) return;                            
      setClosePos({                                                     
        top: Math.max(20, rect.top + 20),                               
        right: Math.max(20, window.innerWidth - rect.right + 20),       
      });                                                               
    });                                   
  }, []); 
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #132 
